### PR TITLE
Add kubebuilder markers for resource path and shortname

### DIFF
--- a/api/v1alpha1/nonadminbackup_types.go
+++ b/api/v1alpha1/nonadminbackup_types.go
@@ -66,6 +66,7 @@ type NonAdminBackupStatus struct {
 
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
+// +kubebuilder:resource:path=nonadminbackups,shortName=nab
 
 // NonAdminBackup is the Schema for the nonadminbackups API
 type NonAdminBackup struct {

--- a/config/crd/bases/nac.oadp.openshift.io_nonadminbackups.yaml
+++ b/config/crd/bases/nac.oadp.openshift.io_nonadminbackups.yaml
@@ -11,6 +11,8 @@ spec:
     kind: NonAdminBackup
     listKind: NonAdminBackupList
     plural: nonadminbackups
+    shortNames:
+    - nab
     singular: nonadminbackup
   scope: Namespaced
   versions:


### PR DESCRIPTION
This PR adds kubebuilder markers to support Non-Admin backups CR's short name.

***What this means ?***
Earlier to fetch non-admin backups CRs you would execute the command 
`oc get nonadminbackups` 
After this PR, you could use the shortname `nab` instead of the fullname `nonadminbackups` 

***How to test ?***
- Install the non-admin backup CRD from this PR
- Try to execute CRUD commands on nonadminbackups CRD/API endpoint using `nab` shortname instead of full name `nonadminbackups` 
for example:
`oc get nab`  