### PR TITLE
Fix for the Reconcile loop is not exitting properly

### DIFF
--- a/internal/controller/nonadminbackup_controller.go
+++ b/internal/controller/nonadminbackup_controller.go
@@ -31,6 +31,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	nacv1alpha1 "github.com/migtools/oadp-non-admin/api/v1alpha1"
 	"github.com/migtools/oadp-non-admin/internal/common/constant"
@@ -89,22 +90,28 @@ func (r *NonAdminBackupReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 	reconcileExit, reconcileRequeue, reconcileErr := r.InitNonAdminBackup(ctx, rLog, &nab)
 	if reconcileRequeue {
 		return ctrl.Result{Requeue: true, RequeueAfter: requeueTimeSeconds * time.Second}, reconcileErr
-	} else if reconcileExit || reconcileErr != nil {
-		return ctrl.Result{}, reconcileErr
+	} else if reconcileExit && reconcileErr != nil {
+		return ctrl.Result{}, reconcile.TerminalError(reconcileErr)
+	} else if reconcileExit {
+		return ctrl.Result{}, nil
 	}
 
 	reconcileExit, reconcileRequeue, reconcileErr = r.ValidateVeleroBackupSpec(ctx, rLog, &nab)
 	if reconcileRequeue {
 		return ctrl.Result{Requeue: true, RequeueAfter: requeueTimeSeconds * time.Second}, reconcileErr
-	} else if reconcileExit || reconcileErr != nil {
-		return ctrl.Result{}, reconcileErr
+	} else if reconcileExit && reconcileErr != nil {
+		return ctrl.Result{}, reconcile.TerminalError(reconcileErr)
+	} else if reconcileExit {
+		return ctrl.Result{}, nil
 	}
 
 	reconcileExit, reconcileRequeue, reconcileErr = r.CreateVeleroBackupSpec(ctx, rLog, &nab)
 	if reconcileRequeue {
 		return ctrl.Result{Requeue: true, RequeueAfter: requeueTimeSeconds * time.Second}, reconcileErr
-	} else if reconcileExit || reconcileErr != nil {
-		return ctrl.Result{}, reconcileErr
+	} else if reconcileExit && reconcileErr != nil {
+		return ctrl.Result{}, reconcile.TerminalError(reconcileErr)
+	} else if reconcileExit {
+		return ctrl.Result{}, nil
 	}
 
 	logger.V(1).Info(">>> Reconcile NonAdminBackup - loop end")


### PR DESCRIPTION
Fixes issue #65

Whenever we want to exit with error state from the reconcile loop that is considered final state we should use TerminalError.

Returning standard error will cause Reconcile to requeue.


## Testing
1. Deploy controller without the change
2. Create NonAdminBackup without proper backupSpec, for example
```yaml
apiVersion: nac.oadp.openshift.io/v1alpha1
kind: NonAdminBackup
metadata:
  name: example
  namespace: nacproject
spec: {}
```

3. Observe controller log. It will show error, however it will re-enter check every few seconds.

With this fix, the point number 3 will not re-enter check every few seconds.

In either scenario proper NonAdminBackup object phase and conditions are correct.