### PR TITLE
ci: fix OADP Go version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,7 +82,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.20" # OADP Go version
+          go-version-file: 'go.mod'
 
       - name: Checkout Non Admin Controller (NAC)
         uses: actions/checkout@v4


### PR DESCRIPTION
## Why the changes were made

Recently, OADP update Go version from 1.20 to 1.22. Our CI is failing because this info is hard coded. This PR automates process of which Go version to use for the OADP job.

## How to test the changes made

Check CI logs. It should not fail as last periodic check https://github.com/migtools/oadp-non-admin/actions/runs/9638007805/job/26578052501
