### PR TITLE
fix: use Go 1.22

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,6 @@ jobs:
       matrix:
         go-version: [
           "1.22",
-          "1.23",
         ]
 
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,9 +18,8 @@ jobs:
     strategy:
       matrix:
         go-version: [
-          "1.20",
-          "1.21",
           "1.22",
+          "1.23",
         ]
 
     steps:
@@ -36,7 +35,7 @@ jobs:
         run: make simulation-test
 
       - name: Go linters
-        if: ${{ matrix.go-version == '1.21' }}
+        if: ${{ matrix.go-version == '1.22' }}
         uses: golangci/golangci-lint-action@v6
         with:
           version: v1.56.2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,17 +15,12 @@ on:
 jobs:
   golang-check:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        go-version: [
-          "1.22",
-        ]
-
     steps:
       - uses: actions/checkout@v4
+
       - uses: actions/setup-go@v5
         with:
-          go-version: ${{ matrix.go-version }}
+          go-version-file: 'go.mod'
 
       - name: Install Go dependencies
         run: go mod download
@@ -34,7 +29,6 @@ jobs:
         run: make simulation-test
 
       - name: Go linters
-        if: ${{ matrix.go-version == '1.22' }}
         uses: golangci/golangci-lint-action@v6
         with:
           version: v1.56.2

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM --platform=$BUILDPLATFORM golang:1.21 AS builder
+FROM --platform=$BUILDPLATFORM golang:1.22 AS builder
 ARG BUILDPLATFORM
 ARG TARGETOS
 ARG TARGETARCH

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -13,7 +13,7 @@ If you are upgrading project's kubebuilder version, please follow [upgrade kubeb
 > **NOTE:** Run `make help` for more information on all potential `make` targets
 
 ## Prerequisites
-- go version v1.21.0+
+- go version v1.22+
 - docker version 17.03+
 - oc
 - Access to a OpenShift cluster

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/migtools/oadp-non-admin
 
-go 1.21
+go 1.22
 
 require (
 	github.com/go-logr/logr v1.4.1


### PR DESCRIPTION
## Why the changes were made

OADP updated Go version to `1.22`. NAC should use same Go version for compatibility.

## How the changes were made

Changed places found by `grep -Iinr '21' .`

## How to test the changes made

Run project commands and check that everything works as expected.
