### PR TITLE
fix: Update NAB status phase and condition together

### DIFF
--- a/internal/common/constant/constant.go
+++ b/internal/common/constant/constant.go
@@ -23,6 +23,7 @@ package constant
 // of the specific Object, such as Backup/Restore.
 const (
 	OadpLabel                    = "openshift.io/oadp" // TODO import?
+	OadpLabelValue               = TrueString
 	ManagedByLabel               = "app.kubernetes.io/managed-by"
 	ManagedByLabelValue          = "oadp-nac-controller" // TODO why not use same project name as in PROJECT file?
 	NabOriginNameAnnotation      = "openshift.io/oadp-nab-origin-name"
@@ -38,8 +39,8 @@ const (
 // EmptyString defines a constant for the empty string
 const EmptyString = ""
 
-// MaxKubernetesNameLength represents maximum length of the name in k8s
-const MaxKubernetesNameLength = 253
+// TrueString defines a constant for the True string
+const TrueString = "True"
 
 // VeleroBackupNamePrefix represents the prefix for the object name generated
 // by the NonAdminController

--- a/internal/handler/velerobackup_handler.go
+++ b/internal/handler/velerobackup_handler.go
@@ -33,12 +33,12 @@ import (
 type VeleroBackupHandler struct{}
 
 // Create event handler
-func (*VeleroBackupHandler) Create(_ context.Context, _ event.CreateEvent, _ workqueue.RateLimitingInterface) {
+func (VeleroBackupHandler) Create(_ context.Context, _ event.CreateEvent, _ workqueue.RateLimitingInterface) {
 	// Create event handler for the Backup object
 }
 
-// Update event handler
-func (*VeleroBackupHandler) Update(ctx context.Context, evt event.UpdateEvent, q workqueue.RateLimitingInterface) {
+// Update event handler adds Velero Backup's NonAdminBackup to controller queue
+func (VeleroBackupHandler) Update(ctx context.Context, evt event.UpdateEvent, q workqueue.RateLimitingInterface) {
 	logger := function.GetLogger(ctx, evt.ObjectNew, "VeleroBackupHandler")
 
 	annotations := evt.ObjectNew.GetAnnotations()
@@ -53,11 +53,11 @@ func (*VeleroBackupHandler) Update(ctx context.Context, evt event.UpdateEvent, q
 }
 
 // Delete event handler
-func (*VeleroBackupHandler) Delete(_ context.Context, _ event.DeleteEvent, _ workqueue.RateLimitingInterface) {
+func (VeleroBackupHandler) Delete(_ context.Context, _ event.DeleteEvent, _ workqueue.RateLimitingInterface) {
 	// Delete event handler for the Backup object
 }
 
 // Generic event handler
-func (*VeleroBackupHandler) Generic(_ context.Context, _ event.GenericEvent, _ workqueue.RateLimitingInterface) {
+func (VeleroBackupHandler) Generic(_ context.Context, _ event.GenericEvent, _ workqueue.RateLimitingInterface) {
 	// Generic event handler for the Backup object
 }

--- a/internal/handler/velerobackup_handler.go
+++ b/internal/handler/velerobackup_handler.go
@@ -20,63 +20,36 @@ package handler
 import (
 	"context"
 
-	"github.com/go-logr/logr"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/util/workqueue"
 	"sigs.k8s.io/controller-runtime/pkg/event"
-	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	"github.com/migtools/oadp-non-admin/internal/common/constant"
+	"github.com/migtools/oadp-non-admin/internal/common/function"
 )
 
 // VeleroBackupHandler contains event handlers for Velero Backup objects
-type VeleroBackupHandler struct {
-	Logger logr.Logger
-}
-
-func getVeleroBackupHandlerLogger(ctx context.Context, name, namespace string) logr.Logger {
-	return log.FromContext(ctx).WithValues("VeleroBackupHandler", types.NamespacedName{Name: name, Namespace: namespace})
-}
+type VeleroBackupHandler struct{}
 
 // Create event handler
-func (*VeleroBackupHandler) Create(ctx context.Context, evt event.CreateEvent, _ workqueue.RateLimitingInterface) {
-	namespace := evt.Object.GetNamespace()
-	name := evt.Object.GetName()
-	logger := getVeleroBackupHandlerLogger(ctx, name, namespace)
-	logger.V(1).Info("Received Create VeleroBackupHandler")
+func (*VeleroBackupHandler) Create(_ context.Context, _ event.CreateEvent, _ workqueue.RateLimitingInterface) {
+	// Create event handler for the Backup object
 }
 
 // Update event handler
 func (*VeleroBackupHandler) Update(ctx context.Context, evt event.UpdateEvent, q workqueue.RateLimitingInterface) {
-	namespace := evt.ObjectNew.GetNamespace()
-	name := evt.ObjectNew.GetName()
-	logger := getVeleroBackupHandlerLogger(ctx, name, namespace)
-	logger.V(1).Info("Received Update VeleroBackupHandler")
+	logger := function.GetLogger(ctx, evt.ObjectNew, "VeleroBackupHandler")
 
 	annotations := evt.ObjectNew.GetAnnotations()
-
-	if annotations == nil {
-		logger.V(1).Info("Backup annotations not found")
-		return
-	}
-
-	nabOriginNamespace, ok := annotations[constant.NabOriginNamespaceAnnotation]
-	if !ok {
-		logger.V(1).Info("Backup NonAdminBackup origin namespace annotation not found")
-		return
-	}
-
-	nabOriginName, ok := annotations[constant.NabOriginNameAnnotation]
-	if !ok {
-		logger.V(1).Info("Backup NonAdminBackup origin name annotation not found")
-		return
-	}
+	nabOriginNamespace := annotations[constant.NabOriginNamespaceAnnotation]
+	nabOriginName := annotations[constant.NabOriginNameAnnotation]
 
 	q.Add(reconcile.Request{NamespacedName: types.NamespacedName{
 		Name:      nabOriginName,
 		Namespace: nabOriginNamespace,
 	}})
+	logger.V(1).Info("Handled Update event")
 }
 
 // Delete event handler

--- a/internal/predicate/composite_predicate.go
+++ b/internal/predicate/composite_predicate.go
@@ -37,13 +37,8 @@ type CompositePredicate struct {
 func (p CompositePredicate) Create(evt event.CreateEvent) bool {
 	switch evt.Object.(type) {
 	case *nacv1alpha1.NonAdminBackup:
-		// Apply NonAdminBackupPredicate
 		return p.NonAdminBackupPredicate.Create(p.Context, evt)
-	case *velerov1.Backup:
-		// Apply VeleroBackupPredicate
-		return p.VeleroBackupPredicate.Create(p.Context, evt)
 	default:
-		// Unknown object type, return false
 		return false
 	}
 }
@@ -65,21 +60,12 @@ func (p CompositePredicate) Delete(evt event.DeleteEvent) bool {
 	switch evt.Object.(type) {
 	case *nacv1alpha1.NonAdminBackup:
 		return p.NonAdminBackupPredicate.Delete(p.Context, evt)
-	case *velerov1.Backup:
-		return p.VeleroBackupPredicate.Delete(p.Context, evt)
 	default:
 		return false
 	}
 }
 
 // Generic event filter
-func (p CompositePredicate) Generic(evt event.GenericEvent) bool {
-	switch evt.Object.(type) {
-	case *nacv1alpha1.NonAdminBackup:
-		return p.NonAdminBackupPredicate.Generic(p.Context, evt)
-	case *velerov1.Backup:
-		return p.VeleroBackupPredicate.Generic(p.Context, evt)
-	default:
-		return false
-	}
+func (CompositePredicate) Generic(_ event.GenericEvent) bool {
+	return false
 }

--- a/internal/predicate/composite_predicate.go
+++ b/internal/predicate/composite_predicate.go
@@ -26,14 +26,14 @@ import (
 	nacv1alpha1 "github.com/migtools/oadp-non-admin/api/v1alpha1"
 )
 
-// CompositePredicate is a combination of all project event filters
+// CompositePredicate is a combination of NonAdminBackup and Velero Backup event filters
 type CompositePredicate struct {
 	Context                 context.Context
 	NonAdminBackupPredicate NonAdminBackupPredicate
 	VeleroBackupPredicate   VeleroBackupPredicate
 }
 
-// Create event filter
+// Create event filter only accepts NonAdminBackup create events
 func (p CompositePredicate) Create(evt event.CreateEvent) bool {
 	switch evt.Object.(type) {
 	case *nacv1alpha1.NonAdminBackup:
@@ -43,7 +43,7 @@ func (p CompositePredicate) Create(evt event.CreateEvent) bool {
 	}
 }
 
-// Update event filter
+// Update event filter accepts both NonAdminBackup and Velero Backup update events
 func (p CompositePredicate) Update(evt event.UpdateEvent) bool {
 	switch evt.ObjectNew.(type) {
 	case *nacv1alpha1.NonAdminBackup:
@@ -55,7 +55,7 @@ func (p CompositePredicate) Update(evt event.UpdateEvent) bool {
 	}
 }
 
-// Delete event filter
+// Delete event filter only accepts NonAdminBackup delete events
 func (p CompositePredicate) Delete(evt event.DeleteEvent) bool {
 	switch evt.Object.(type) {
 	case *nacv1alpha1.NonAdminBackup:
@@ -65,7 +65,7 @@ func (p CompositePredicate) Delete(evt event.DeleteEvent) bool {
 	}
 }
 
-// Generic event filter
+// Generic event filter does not accept any generic events
 func (CompositePredicate) Generic(_ event.GenericEvent) bool {
 	return false
 }

--- a/internal/predicate/nonadminbackup_predicate.go
+++ b/internal/predicate/nonadminbackup_predicate.go
@@ -32,8 +32,6 @@ type NonAdminBackupPredicate struct{}
 // Create event filter
 func (NonAdminBackupPredicate) Create(ctx context.Context, evt event.CreateEvent) bool {
 	logger := function.GetLogger(ctx, evt.Object, nonAdminBackupPredicateKey)
-	logger.V(1).Info("Received Create event")
-
 	logger.V(1).Info("Accepted Create event")
 	return true
 }
@@ -41,7 +39,6 @@ func (NonAdminBackupPredicate) Create(ctx context.Context, evt event.CreateEvent
 // Update event filter
 func (NonAdminBackupPredicate) Update(ctx context.Context, evt event.UpdateEvent) bool {
 	logger := function.GetLogger(ctx, evt.ObjectNew, nonAdminBackupPredicateKey)
-	logger.V(1).Info("Received Update event")
 
 	// spec change
 	if evt.ObjectNew.GetGeneration() != evt.ObjectOld.GetGeneration() {
@@ -56,8 +53,6 @@ func (NonAdminBackupPredicate) Update(ctx context.Context, evt event.UpdateEvent
 // Delete event filter
 func (NonAdminBackupPredicate) Delete(ctx context.Context, evt event.DeleteEvent) bool {
 	logger := function.GetLogger(ctx, evt.Object, nonAdminBackupPredicateKey)
-	logger.V(1).Info("Received Delete event")
-
 	logger.V(1).Info("Accepted Delete event")
 	return true
 }

--- a/internal/predicate/nonadminbackup_predicate.go
+++ b/internal/predicate/nonadminbackup_predicate.go
@@ -29,14 +29,14 @@ const nonAdminBackupPredicateKey = "NonAdminBackupPredicate"
 // NonAdminBackupPredicate contains event filters for Non Admin Backup objects
 type NonAdminBackupPredicate struct{}
 
-// Create event filter
+// Create event filter accepts all NonAdminBackup create events
 func (NonAdminBackupPredicate) Create(ctx context.Context, evt event.CreateEvent) bool {
 	logger := function.GetLogger(ctx, evt.Object, nonAdminBackupPredicateKey)
 	logger.V(1).Info("Accepted Create event")
 	return true
 }
 
-// Update event filter
+// Update event filter only accepts NonAdminBackup update events that include spec change
 func (NonAdminBackupPredicate) Update(ctx context.Context, evt event.UpdateEvent) bool {
 	logger := function.GetLogger(ctx, evt.ObjectNew, nonAdminBackupPredicateKey)
 
@@ -50,7 +50,7 @@ func (NonAdminBackupPredicate) Update(ctx context.Context, evt event.UpdateEvent
 	return false
 }
 
-// Delete event filter
+// Delete event filter accepts all NonAdminBackup delete events
 func (NonAdminBackupPredicate) Delete(ctx context.Context, evt event.DeleteEvent) bool {
 	logger := function.GetLogger(ctx, evt.Object, nonAdminBackupPredicateKey)
 	logger.V(1).Info("Accepted Delete event")

--- a/internal/predicate/velerobackup_predicate.go
+++ b/internal/predicate/velerobackup_predicate.go
@@ -34,7 +34,6 @@ type VeleroBackupPredicate struct {
 // Update event filter
 func (veleroBackupPredicate VeleroBackupPredicate) Update(ctx context.Context, evt event.UpdateEvent) bool {
 	logger := function.GetLogger(ctx, evt.ObjectNew, "VeleroBackupPredicate")
-	logger.V(1).Info("Received Update event")
 
 	namespace := evt.ObjectNew.GetNamespace()
 	if namespace == veleroBackupPredicate.OadpVeleroNamespace {

--- a/internal/predicate/velerobackup_predicate.go
+++ b/internal/predicate/velerobackup_predicate.go
@@ -26,17 +26,16 @@ import (
 
 // VeleroBackupPredicate contains event filters for Velero Backup objects
 type VeleroBackupPredicate struct {
-	// We are watching only Velero Backup objects within
-	// namespace where OADP is.
-	OadpVeleroNamespace string
+	OADPNamespace string
 }
 
-// Update event filter
-func (veleroBackupPredicate VeleroBackupPredicate) Update(ctx context.Context, evt event.UpdateEvent) bool {
+// Update event filter only accepts Velero Backup update events from OADP namespace
+// and from Velero Backups that have required metadata
+func (p VeleroBackupPredicate) Update(ctx context.Context, evt event.UpdateEvent) bool {
 	logger := function.GetLogger(ctx, evt.ObjectNew, "VeleroBackupPredicate")
 
 	namespace := evt.ObjectNew.GetNamespace()
-	if namespace == veleroBackupPredicate.OadpVeleroNamespace {
+	if namespace == p.OADPNamespace {
 		if function.CheckVeleroBackupMetadata(evt.ObjectNew) {
 			logger.V(1).Info("Accepted Update event")
 			return true


### PR DESCRIPTION
## Why the changes were made

As discussed with the team, we want to do less reconcile steps for NAB full reconcile loop (but keeping only making one update call per reconcile). With this PR, NAB reconcile update phases and conditions together in one update call.

Also, simplified Predicate and Handlers logic.

## How to test the changes made

Run tests and check logs (`make simulation-test`) or test in a cluster following [development documentation](https://github.com/migtools/oadp-non-admin/blob/master/docs/CONTRIBUTING.md#install-from-source). 
