### PR TITLE
fix: Re-enable CRD check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,5 +85,6 @@ jobs:
         run: |
           NON_ADMIN_CONTROLLER_PATH=./oadp-non-admin make update-non-admin-manifests
           if test -n "$(git status --short -- ':!oadp-non-admin')"; then
-            echo "::warning::run 'make update-non-admin-manifests' in OADP repository to update Non Admin Controller (NAC) manifests"
+            echo "::error::run 'make update-non-admin-manifests' in OADP repository to update Non Admin Controller (NAC) manifests"
+            exit 1
           fi

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -20,12 +20,19 @@ If you are upgrading project's kubebuilder version, please follow [upgrade kubeb
 
 ## Install from source
 
-To install OADP operator in your cluster, with OADP NAC from current branch, run
+To install OADP operator from default or a release branch in your cluster, with related OADP NAC from default or same release branch, run
 ```sh
-export DEV_IMG=ttl.sh/oadp-non-admin-$(git rev-parse --short HEAD)-$(echo $RANDOM):1h
-export NAC_PATH=$PWD
 git clone --depth=1 git@github.com:openshift/oadp-operator.git -b master # or appropriate branch
+cd oadp-operator
+make deploy-olm
+```
+
+To install OADP operator from a branch in your cluster, with OADP NAC from current development branch (a PR branch, for example), run
+```sh
+export NAC_PATH=$PWD # or appropriate NAC repository path, already with current branch pointing to development branch
+export DEV_IMG=ttl.sh/oadp-non-admin-$(git rev-parse --short HEAD)-$(echo $RANDOM):1h
 IMG=$DEV_IMG make docker-build docker-push
+git clone --depth=1 git@github.com:openshift/oadp-operator.git -b master # or appropriate branch
 cd oadp-operator
 NON_ADMIN_CONTROLLER_PATH=$NAC_PATH NON_ADMIN_CONTROLLER_IMG=$DEV_IMG make update-non-admin-manifests deploy-olm
 ```


### PR DESCRIPTION
## Why the changes were made

We are planning a test day and with CRDs outdated in OADP, it is harder to configure test environment in a cluster.

Fixes #50

## How to test the changes made

Check CI logs, it should enforce that CRDs are up to date.

Also follow [development documentation](https://github.com/mateusoliveira43/oadp-non-admin/blob/fix/crd-check/docs/CONTRIBUTING.md#install-from-source) and check it is working. 

