### PR TITLE
fix: Check Go dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,9 @@ jobs:
         with:
           version: v1.56.2
 
+      - name: Go dependencies
+        run: make check-go-dependencies
+
   container-check:
     runs-on: ubuntu-latest
     steps:

--- a/Makefile
+++ b/Makefile
@@ -227,7 +227,7 @@ editorconfig: $(LOCALBIN) ## Download editorconfig locally if necessary.
 COVERAGE_THRESHOLD=60
 
 .PHONY: ci
-ci: simulation-test lint docker-build hadolint check-generate check-manifests ec check-images ## Run all project continuous integration (CI) checks locally.
+ci: simulation-test lint docker-build hadolint check-generate check-manifests ec check-go-dependencies check-images ## Run all project continuous integration (CI) checks locally.
 
 .PHONY: simulation-test
 simulation-test: envtest ## Run unit and integration tests.
@@ -261,6 +261,12 @@ check-manifests: manifests ## Check if 'make manifests' was run.
 .PHONY: ec
 ec: editorconfig ## Run file formatter checks against all project's files.
 	$(EC)
+
+.PHONY: check-go-dependencies
+check-go-dependencies: ## Check if 'go mod tidy' was run.
+	go mod tidy
+	go mod verify
+	test -z "$(shell git status --short)" || (echo "run 'go mod tidy' to update go dependencies" && exit 1)
 
 .PHONY: check-images
 check-images: MANAGER_IMAGE:=$(shell grep -I 'newName: ' ./config/manager/kustomization.yaml | awk -F': ' '{print $$2}')

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -81,6 +81,13 @@ make ec
 
 Files format configuration in [`.editorconfig`](../.editorconfig) file.
 
+### Go dependencies
+
+To check if project's Go dependencies are ok, run
+```sh
+make check-go-dependencies
+```
+
 ### Container file linter
 
 To run container file linter, run


### PR DESCRIPTION
## Why the changes were made

Ensure `go mod tidy` is always ran.

## How to test the changes made

Run new command, `make check-go-dependencies`, and check if it works properly.
