### PR TITLE
fix: go mod tidy verification

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,8 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version-file: 'go.mod'
+          go-version-file: go.mod
+          cache: false
 
       - name: Install Go dependencies
         run: go mod download
@@ -77,7 +78,8 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version-file: 'go.mod'
+          go-version-file: go.mod
+          cache: false
 
       - name: Checkout Non Admin Controller (NAC)
         uses: actions/checkout@v4

--- a/Makefile
+++ b/Makefile
@@ -262,11 +262,14 @@ check-manifests: manifests ## Check if 'make manifests' was run.
 ec: editorconfig ## Run file formatter checks against all project's files.
 	$(EC)
 
-.PHONY: check-go-dependencies
-check-go-dependencies: ## Check if 'go mod tidy' was run.
+.PHONY: go-dependencies
+go-dependencies: ## Update go dependencies.
 	go mod tidy
 	go mod verify
-	test -z "$(shell git status --short)" || (echo "run 'go mod tidy' to update go dependencies" && exit 1)
+
+.PHONY: check-go-dependencies
+check-go-dependencies: go-dependencies ## Check if 'make go-dependencies' was run.
+	test -z "$(shell git status --short)" || (echo "run 'make go-dependencies' to update go dependencies" && exit 1)
 
 .PHONY: check-images
 check-images: MANAGER_IMAGE:=$(shell grep -I 'newName: ' ./config/manager/kustomization.yaml | awk -F': ' '{print $$2}')

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ toolchain go1.22.6
 
 require (
 	github.com/go-logr/logr v1.4.1
+	github.com/google/uuid v1.6.0
 	github.com/onsi/ginkgo/v2 v2.19.0
 	github.com/onsi/gomega v1.33.1
 	github.com/stretchr/testify v1.9.0
@@ -36,7 +37,6 @@ require (
 	github.com/google/go-cmp v0.6.0 // indirect
 	github.com/google/gofuzz v1.2.0 // indirect
 	github.com/google/pprof v0.0.0-20240424215950-a892ee059fd6 // indirect
-	github.com/google/uuid v1.6.0 // indirect
 	github.com/imdario/mergo v0.3.13 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect


### PR DESCRIPTION
## Why the changes were made

Noticed that CI was not enforcing `go mod tidy` to be run on PRs. Problem was the way the command was being called in Makefile. It needs to be broken into 2 commands to work.

## How to test the changes made

Check CI logs.

[bad run](https://github.com/migtools/oadp-non-admin/actions/runs/11799095918/job/32866808091)

[good run](https://github.com/migtools/oadp-non-admin/actions/runs/11799208873/job/32867178891)
