### PR TITLE
Fix "cannot range over" local lint errors

### DIFF
--- a/internal/common/function/function.go
+++ b/internal/common/function/function.go
@@ -145,7 +145,7 @@ func ValidateRestoreSpec(ctx context.Context, clientInstance client.Client, nonA
 	// TODO nonAdminRestore.Spec.RestoreSpec.NamespaceMapping ?
 
 	enforcedSpec := reflect.ValueOf(enforcedRestoreSpec).Elem()
-	for index := range enforcedSpec.NumField() {
+	for index := 0; index < enforcedSpec.NumField(); index++ {
 		enforcedField := enforcedSpec.Field(index)
 		enforcedFieldName := enforcedSpec.Type().Field(index).Name
 		currentField := reflect.ValueOf(nonAdminRestore.Spec.RestoreSpec).Elem().FieldByName(enforcedFieldName)

--- a/internal/common/function/function_test.go
+++ b/internal/common/function/function_test.go
@@ -676,7 +676,7 @@ func TestValidateRestoreSpecEnforcedFields(t *testing.T) {
 			restoreSpecFields = append(restoreSpecFields, test.name)
 		}
 		restoreSpec := reflect.ValueOf(&velerov1.RestoreSpec{}).Elem()
-		for index := range restoreSpec.NumField() {
+		for index := 0; index < restoreSpec.NumField(); index++ {
 			if !slices.Contains(restoreSpecFields, restoreSpec.Type().Field(index).Name) {
 				t.Errorf("restore spec field '%v' is not tested", restoreSpec.Type().Field(index).Name)
 			}

--- a/internal/controller/nonadminrestore_controller.go
+++ b/internal/controller/nonadminrestore_controller.go
@@ -346,7 +346,7 @@ func (r *NonAdminRestoreReconciler) createVeleroRestore(ctx context.Context, log
 		restoreSpec.IncludedNamespaces = []string{nar.Namespace}
 
 		enforcedSpec := reflect.ValueOf(r.EnforcedRestoreSpec).Elem()
-		for index := range enforcedSpec.NumField() {
+		for index := 0; index < enforcedSpec.NumField(); index++ {
 			enforcedField := enforcedSpec.Field(index)
 			enforcedFieldName := enforcedSpec.Type().Field(index).Name
 			currentField := reflect.ValueOf(restoreSpec).Elem().FieldByName(enforcedFieldName)


### PR DESCRIPTION
With the #122 local error on the make lint
appeared. This is not visible in the CI, however local go version and lint version are the same, so may be associated with other dependent libraries.

Still this is an issue when submitting a PR from the system where this linting error is visible.

For error message and insights:
  https://github.com/migtools/oadp-non-admin/pull/122#issuecomment-2515304578

## Why the changes were made

<!-- Explain why this PR is important, what problems it fixes, link related issues -->

To fix local `$ make lint` errors introduced with #122 

## How to test the changes made

<!-- Explain how the changes introduced by this PR can be tested and verified, with commands and pictures -->

Ran the lint after change, no error appeared.