### PR TITLE
fix: lint warns

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,13 +1,12 @@
 # Documentation reference https://github.com/golangci/golangci-lint/blob/v1.62.2/.golangci.reference.yml
 run:
-  skip-dirs-use-default: false
   modules-download-mode: readonly
   allow-parallel-runners: true
-  skip-dirs:
-    - test/*
 
 output:
-  format: colored-line-number
+  formats:
+    - format: colored-line-number
+      path: stdout
   print-issued-lines: true
   print-linter-name: true
   uniq-by-line: true
@@ -91,12 +90,12 @@ linters:
     - asciicheck
     - bidichk
     - bodyclose
+    - copyloopvar
     - dogsled
     - dupword
     - durationcheck
     - errcheck
     - errchkjson
-    - exportloopref
     - gci
     - ginkgolinter
     - goconst
@@ -125,6 +124,9 @@ linters:
   fast: false
 
 issues:
+  exclude-dirs:
+    - test/*
+  exclude-dirs-use-default: false
   exclude-use-default: false
   exclude-rules:
     - linters:


### PR DESCRIPTION
## Why the changes were made

Fix WARNs when running `make lint` command 

## How to test the changes made

On master branch, when running `make lint` command, you should see the following WARNs
```
WARN [config_reader] The configuration option `run.skip-dirs` is deprecated, please use `issues.exclude-dirs`. 
WARN [config_reader] The configuration option `run.skip-dirs-use-default` is deprecated, please use `issues.exclude-dirs-use-default`. 
WARN [config_reader] The configuration option `output.format` is deprecated, please use `output.formats` 
WARN The linter 'exportloopref' is deprecated (since v1.60.2) due to: Since Go1.22 (loopvar) this linter is no longer relevant. Replaced by copyloopvar. 
```

On this branch, you should see no WARNs
