### PR TITLE
Move API conditions and phases into common api file

### DIFF
--- a/api/v1alpha1/nonadmin_types.go
+++ b/api/v1alpha1/nonadmin_types.go
@@ -47,6 +47,6 @@ const (
 
 // QueueInfo holds the queue position for a specific operation.
 type QueueInfo struct {
-	// estimatedQueuePosition is the number of backups ahead in the queue (0 if not queued)
+	// estimatedQueuePosition is the number of operations ahead in the queue (0 if not queued)
 	EstimatedQueuePosition int `json:"estimatedQueuePosition"`
 }

--- a/api/v1alpha1/nonadmin_types.go
+++ b/api/v1alpha1/nonadmin_types.go
@@ -1,0 +1,52 @@
+/*
+Copyright 2024.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha1
+
+// NonAdminPhase is a simple one high-level summary of the lifecycle of a NonAdminBackup or NonAdminRestore.
+// +kubebuilder:validation:Enum=New;BackingOff;Created;Deleting
+type NonAdminPhase string
+
+const (
+	// NonAdminPhaseNew - NonAdmin object was accepted by the OpenShift cluster, but it has not yet been processed by the NonAdminController
+	NonAdminPhaseNew NonAdminPhase = "New"
+	// NonAdminPhaseBackingOff - Velero object was not created due to NonAdmin object error (configuration or similar)
+	NonAdminPhaseBackingOff NonAdminPhase = "BackingOff"
+	// NonAdminPhaseCreated - Velero object was created. The Phase will not have additional information about it.
+	NonAdminPhaseCreated NonAdminPhase = "Created"
+	// NonAdminPhaseDeleting - Velero object is pending deletion. The Phase will not have additional information about it.
+	NonAdminPhaseDeleting NonAdminPhase = "Deleting"
+)
+
+// NonAdminCondition are used for more detailed information supporing NonAdminBackupPhase state.
+// +kubebuilder:validation:Enum=Accepted;Queued;Deleting
+type NonAdminCondition string
+
+// Predefined conditions for NonAdminController objects.
+// One NonAdminController object may have multiple conditions.
+// It is more granular knowledge of the NonAdminController object and represents the
+// array of the conditions through which the NonAdminController has or has not passed
+const (
+	NonAdminConditionAccepted NonAdminCondition = "Accepted"
+	NonAdminConditionQueued   NonAdminCondition = "Queued"
+	NonAdminConditionDeleting NonAdminCondition = "Deleting"
+)
+
+// QueueInfo holds the queue position for a specific operation.
+type QueueInfo struct {
+	// estimatedQueuePosition is the number of backups ahead in the queue (0 if not queued)
+	EstimatedQueuePosition int `json:"estimatedQueuePosition"`
+}

--- a/api/v1alpha1/nonadminbackup_types.go
+++ b/api/v1alpha1/nonadminbackup_types.go
@@ -21,21 +21,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-// NonAdminPhase is a simple one high-level summary of the lifecycle of an NonAdminBackup.
-// +kubebuilder:validation:Enum=New;BackingOff;Created;Deleting
-type NonAdminPhase string
-
-const (
-	// NonAdminPhaseNew - NonAdmin object was accepted by the OpenShift cluster, but it has not yet been processed by the NonAdminController
-	NonAdminPhaseNew NonAdminPhase = "New"
-	// NonAdminPhaseBackingOff - Velero object was not created due to NonAdmin object error (configuration or similar)
-	NonAdminPhaseBackingOff NonAdminPhase = "BackingOff"
-	// NonAdminPhaseCreated - Velero object was created. The Phase will not have additional information about it.
-	NonAdminPhaseCreated NonAdminPhase = "Created"
-	// NonAdminPhaseDeleting - Velero object is pending deletion. The Phase will not have additional information about it.
-	NonAdminPhaseDeleting NonAdminPhase = "Deleting"
-)
-
 // NonAdminBackupSpec defines the desired state of NonAdminBackup
 type NonAdminBackupSpec struct {
 	// BackupSpec defines the specification for a Velero backup.
@@ -98,6 +83,10 @@ type NonAdminBackupStatus struct {
 	// +optional
 	VeleroDeleteBackupRequest *VeleroDeleteBackupRequest `json:"veleroDeleteBackupRequest,omitempty"`
 
+	// queueInfo is used to estimate how many backups are scheduled before the given VeleroBackup in the OADP namespace.
+	// This number is not guaranteed to be accurate, but it should be close. It's inaccurate for cases when
+	// Velero pod is not running or being restarted after Backup object were created.
+	// It counts only VeleroBackups that are still subject to be handled by OADP/Velero.
 	// +optional
 	QueueInfo *QueueInfo `json:"queueInfo,omitempty"`
 
@@ -105,15 +94,6 @@ type NonAdminBackupStatus struct {
 	Phase NonAdminPhase `json:"phase,omitempty"`
 
 	Conditions []metav1.Condition `json:"conditions,omitempty"`
-}
-
-// QueueInfo holds the queue position for a specific VeleroBackup.
-// It is used to estimate how many backups are scheduled before the given VeleroBackup in the OADP namespace.
-// This number is not guaranteed to be accurate, but it should be close. It's inaccurate for cases when
-// Velero pod is not running or being restarted after Backup object were created.
-// It counts only VeleroBackups that are still subject to be handled by OADP/Velero.
-type QueueInfo struct {
-	EstimatedQueuePosition int `json:"estimatedQueuePosition"` // Number of backups ahead in the queue (0 if not queued)
 }
 
 // +kubebuilder:object:root=true

--- a/config/crd/bases/oadp.openshift.io_nonadminbackups.yaml
+++ b/config/crd/bases/oadp.openshift.io_nonadminbackups.yaml
@@ -617,8 +617,8 @@ spec:
                   It counts only VeleroBackups that are still subject to be handled by OADP/Velero.
                 properties:
                   estimatedQueuePosition:
-                    description: estimatedQueuePosition is the number of backups ahead
-                      in the queue (0 if not queued)
+                    description: estimatedQueuePosition is the number of operations
+                      ahead in the queue (0 if not queued)
                     type: integer
                 required:
                 - estimatedQueuePosition

--- a/config/crd/bases/oadp.openshift.io_nonadminbackups.yaml
+++ b/config/crd/bases/oadp.openshift.io_nonadminbackups.yaml
@@ -611,13 +611,14 @@ spec:
                 type: string
               queueInfo:
                 description: |-
-                  QueueInfo holds the queue position for a specific VeleroBackup.
-                  It is used to estimate how many backups are scheduled before the given VeleroBackup in the OADP namespace.
+                  queueInfo is used to estimate how many backups are scheduled before the given VeleroBackup in the OADP namespace.
                   This number is not guaranteed to be accurate, but it should be close. It's inaccurate for cases when
                   Velero pod is not running or being restarted after Backup object were created.
                   It counts only VeleroBackups that are still subject to be handled by OADP/Velero.
                 properties:
                   estimatedQueuePosition:
+                    description: estimatedQueuePosition is the number of backups ahead
+                      in the queue (0 if not queued)
                     type: integer
                 required:
                 - estimatedQueuePosition

--- a/internal/common/constant/constant.go
+++ b/internal/common/constant/constant.go
@@ -39,8 +39,8 @@ const (
 	NarOriginNameAnnotation      = v1alpha1.OadpOperatorLabel + "-nar-origin-name"
 	NarOriginNamespaceAnnotation = v1alpha1.OadpOperatorLabel + "-nar-origin-namespace"
 
-	NabFinalizerName             = "nonadminbackup.oadp.openshift.io/finalizer"
-	NonAdminRestoreFinalizerName = "nonadminrestore.oadp.openshift.io/finalizer"
+	NabFinalizerName = "nonadminbackup.oadp.openshift.io/finalizer"
+	NarFinalizerName = "nonadminrestore.oadp.openshift.io/finalizer"
 )
 
 // Common environment variables for the Non Admin Controller
@@ -60,16 +60,15 @@ const TrueString = "True"
 // NamespaceString defines a constant for the Namespace string
 const NamespaceString = "Namespace"
 
+// NameString defines a constant for the Name string
+const NameString = "name"
+
+// CurrentPhaseString defines a constant for the Current Phase string
+const CurrentPhaseString = "currentPhase"
+
+// UUIDString defines a constant for the UUID string
+const UUIDString = "UUID"
+
 // MaximumNacObjectNameLength represents Generated Non Admin Object Name and
 // must be below 63 characters, because it's used within object Label Value
 const MaximumNacObjectNameLength = validation.DNS1123LabelMaxLength
-
-// Predefined conditions for NonAdmin object.
-// One NonAdmin object may have multiple conditions.
-// It is more granular knowledge of the NonAdmin object and represents the
-// array of the conditions through which the NonAdmin object has or has not passed
-const (
-	NonAdminConditionAccepted = "Accepted"
-	NonAdminConditionQueued   = "Queued"
-	NonAdminConditionDeleting = "Deleting"
-)

--- a/internal/common/function/function.go
+++ b/internal/common/function/function.go
@@ -350,7 +350,7 @@ func GetVeleroRestoreByLabel(ctx context.Context, clientInstance client.Client, 
 	case 1:
 		return &veleroRestoreList.Items[0], nil
 	default:
-		return nil, fmt.Errorf("multiple Velero Restore objects found with label %s=%s in namespace '%s'", constant.NabOriginNACUUIDLabel, labelValue, namespace)
+		return nil, fmt.Errorf("multiple Velero Restore objects found with label %s=%s in namespace '%s'", constant.NarOriginNACUUIDLabel, labelValue, namespace)
 	}
 }
 

--- a/internal/controller/nonadminbackup_controller_test.go
+++ b/internal/controller/nonadminbackup_controller_test.go
@@ -380,7 +380,7 @@ var _ = ginkgo.Describe("Test single reconciles of NonAdminBackup Reconcile func
 				Phase: nacv1alpha1.NonAdminPhaseBackingOff,
 				Conditions: []metav1.Condition{
 					{
-						Type:    string(constant.NonAdminConditionAccepted),
+						Type:    string(nacv1alpha1.NonAdminConditionAccepted),
 						Status:  metav1.ConditionFalse,
 						Reason:  "InvalidBackupSpec",
 						Message: "NonAdminBackup spec.backupSpec.includedNamespaces can not contain namespaces other than: ",
@@ -400,7 +400,7 @@ var _ = ginkgo.Describe("Test single reconciles of NonAdminBackup Reconcile func
 				Phase: nacv1alpha1.NonAdminPhaseBackingOff,
 				Conditions: []metav1.Condition{
 					{
-						Type:               string(constant.NonAdminConditionAccepted),
+						Type:               string(nacv1alpha1.NonAdminConditionAccepted),
 						Status:             metav1.ConditionFalse,
 						Reason:             "InvalidBackupSpec",
 						Message:            "BackupSpec is not defined",
@@ -421,14 +421,14 @@ var _ = ginkgo.Describe("Test single reconciles of NonAdminBackup Reconcile func
 				Phase: nacv1alpha1.NonAdminPhaseCreated,
 				Conditions: []metav1.Condition{
 					{
-						Type:               string(constant.NonAdminConditionAccepted),
+						Type:               string(nacv1alpha1.NonAdminConditionAccepted),
 						Status:             metav1.ConditionTrue,
 						Reason:             "BackupAccepted",
 						Message:            "backup accepted",
 						LastTransitionTime: metav1.NewTime(time.Now()),
 					},
 					{
-						Type:               string(constant.NonAdminConditionQueued),
+						Type:               string(nacv1alpha1.NonAdminConditionQueued),
 						Status:             metav1.ConditionTrue,
 						Reason:             "BackupScheduled",
 						Message:            "Created Velero Backup object",
@@ -440,19 +440,19 @@ var _ = ginkgo.Describe("Test single reconciles of NonAdminBackup Reconcile func
 				Phase: nacv1alpha1.NonAdminPhaseDeleting,
 				Conditions: []metav1.Condition{
 					{
-						Type:    string(constant.NonAdminConditionAccepted),
+						Type:    string(nacv1alpha1.NonAdminConditionAccepted),
 						Status:  metav1.ConditionTrue,
 						Reason:  "BackupAccepted",
 						Message: "backup accepted",
 					},
 					{
-						Type:    string(constant.NonAdminConditionQueued),
+						Type:    string(nacv1alpha1.NonAdminConditionQueued),
 						Status:  metav1.ConditionTrue,
 						Reason:  "BackupScheduled",
 						Message: "Created Velero Backup object",
 					},
 					{
-						Type:    string(constant.NonAdminConditionDeleting),
+						Type:    string(nacv1alpha1.NonAdminConditionDeleting),
 						Status:  metav1.ConditionTrue,
 						Reason:  "DeletionPending",
 						Message: "backup accepted for deletion",
@@ -473,21 +473,21 @@ var _ = ginkgo.Describe("Test single reconciles of NonAdminBackup Reconcile func
 				Phase: nacv1alpha1.NonAdminPhaseDeleting,
 				Conditions: []metav1.Condition{
 					{
-						Type:               string(constant.NonAdminConditionAccepted),
+						Type:               string(nacv1alpha1.NonAdminConditionAccepted),
 						Status:             metav1.ConditionTrue,
 						Reason:             "BackupAccepted",
 						Message:            "backup accepted",
 						LastTransitionTime: metav1.NewTime(time.Now()),
 					},
 					{
-						Type:               string(constant.NonAdminConditionQueued),
+						Type:               string(nacv1alpha1.NonAdminConditionQueued),
 						Status:             metav1.ConditionTrue,
 						Reason:             "BackupScheduled",
 						Message:            "Created Velero Backup object",
 						LastTransitionTime: metav1.NewTime(time.Now()),
 					},
 					{
-						Type:               string(constant.NonAdminConditionDeleting),
+						Type:               string(nacv1alpha1.NonAdminConditionDeleting),
 						Status:             metav1.ConditionTrue,
 						Reason:             "DeletionPending",
 						Message:            "backup accepted for deletion",
@@ -499,19 +499,19 @@ var _ = ginkgo.Describe("Test single reconciles of NonAdminBackup Reconcile func
 				Phase: nacv1alpha1.NonAdminPhaseDeleting,
 				Conditions: []metav1.Condition{
 					{
-						Type:    string(constant.NonAdminConditionAccepted),
+						Type:    string(nacv1alpha1.NonAdminConditionAccepted),
 						Status:  metav1.ConditionTrue,
 						Reason:  "BackupAccepted",
 						Message: "backup accepted",
 					},
 					{
-						Type:    string(constant.NonAdminConditionQueued),
+						Type:    string(nacv1alpha1.NonAdminConditionQueued),
 						Status:  metav1.ConditionTrue,
 						Reason:  "BackupScheduled",
 						Message: "Created Velero Backup object",
 					},
 					{
-						Type:    string(constant.NonAdminConditionDeleting),
+						Type:    string(nacv1alpha1.NonAdminConditionDeleting),
 						Status:  metav1.ConditionTrue,
 						Reason:  "DeletionPending",
 						Message: "backup accepted for deletion",
@@ -531,14 +531,14 @@ var _ = ginkgo.Describe("Test single reconciles of NonAdminBackup Reconcile func
 				Phase: nacv1alpha1.NonAdminPhaseCreated,
 				Conditions: []metav1.Condition{
 					{
-						Type:               string(constant.NonAdminConditionAccepted),
+						Type:               string(nacv1alpha1.NonAdminConditionAccepted),
 						Status:             metav1.ConditionTrue,
 						Reason:             "BackupAccepted",
 						Message:            "backup accepted",
 						LastTransitionTime: metav1.NewTime(time.Now()),
 					},
 					{
-						Type:               string(constant.NonAdminConditionQueued),
+						Type:               string(nacv1alpha1.NonAdminConditionQueued),
 						Status:             metav1.ConditionTrue,
 						Reason:             "BackupScheduled",
 						Message:            "Created Velero Backup object",
@@ -560,14 +560,14 @@ var _ = ginkgo.Describe("Test single reconciles of NonAdminBackup Reconcile func
 				Phase: nacv1alpha1.NonAdminPhaseCreated,
 				Conditions: []metav1.Condition{
 					{
-						Type:               string(constant.NonAdminConditionAccepted),
+						Type:               string(nacv1alpha1.NonAdminConditionAccepted),
 						Status:             metav1.ConditionTrue,
 						Reason:             "BackupAccepted",
 						Message:            "backup accepted",
 						LastTransitionTime: metav1.NewTime(time.Now()),
 					},
 					{
-						Type:               string(constant.NonAdminConditionQueued),
+						Type:               string(nacv1alpha1.NonAdminConditionQueued),
 						Status:             metav1.ConditionTrue,
 						Reason:             "BackupScheduled",
 						Message:            "Created Velero Backup object",
@@ -579,19 +579,19 @@ var _ = ginkgo.Describe("Test single reconciles of NonAdminBackup Reconcile func
 				Phase: nacv1alpha1.NonAdminPhaseDeleting,
 				Conditions: []metav1.Condition{
 					{
-						Type:    string(constant.NonAdminConditionAccepted),
+						Type:    string(nacv1alpha1.NonAdminConditionAccepted),
 						Status:  metav1.ConditionTrue,
 						Reason:  "BackupAccepted",
 						Message: "backup accepted",
 					},
 					{
-						Type:    string(constant.NonAdminConditionQueued),
+						Type:    string(nacv1alpha1.NonAdminConditionQueued),
 						Status:  metav1.ConditionTrue,
 						Reason:  "BackupScheduled",
 						Message: "Created Velero Backup object",
 					},
 					{
-						Type:    string(constant.NonAdminConditionDeleting),
+						Type:    string(nacv1alpha1.NonAdminConditionDeleting),
 						Status:  metav1.ConditionTrue,
 						Reason:  "DeletionPending",
 						Message: "backup accepted for deletion",
@@ -612,21 +612,21 @@ var _ = ginkgo.Describe("Test single reconciles of NonAdminBackup Reconcile func
 				Phase: nacv1alpha1.NonAdminPhaseDeleting,
 				Conditions: []metav1.Condition{
 					{
-						Type:               string(constant.NonAdminConditionAccepted),
+						Type:               string(nacv1alpha1.NonAdminConditionAccepted),
 						Status:             metav1.ConditionTrue,
 						Reason:             "BackupAccepted",
 						Message:            "backup accepted",
 						LastTransitionTime: metav1.NewTime(time.Now()),
 					},
 					{
-						Type:               string(constant.NonAdminConditionQueued),
+						Type:               string(nacv1alpha1.NonAdminConditionQueued),
 						Status:             metav1.ConditionTrue,
 						Reason:             "BackupScheduled",
 						Message:            "Created Velero Backup object",
 						LastTransitionTime: metav1.NewTime(time.Now()),
 					},
 					{
-						Type:               string(constant.NonAdminConditionDeleting),
+						Type:               string(nacv1alpha1.NonAdminConditionDeleting),
 						Status:             metav1.ConditionTrue,
 						Reason:             "DeletionPending",
 						Message:            "backup accepted for deletion",
@@ -650,13 +650,13 @@ var _ = ginkgo.Describe("Test single reconciles of NonAdminBackup Reconcile func
 				Phase: nacv1alpha1.NonAdminPhaseCreated,
 				Conditions: []metav1.Condition{
 					{
-						Type:    string(constant.NonAdminConditionAccepted),
+						Type:    string(nacv1alpha1.NonAdminConditionAccepted),
 						Status:  metav1.ConditionTrue,
 						Reason:  "BackupAccepted",
 						Message: "backup accepted",
 					},
 					{
-						Type:    string(constant.NonAdminConditionQueued),
+						Type:    string(nacv1alpha1.NonAdminConditionQueued),
 						Status:  metav1.ConditionTrue,
 						Reason:  "BackupScheduled",
 						Message: "Created Velero Backup object",
@@ -673,7 +673,7 @@ var _ = ginkgo.Describe("Test single reconciles of NonAdminBackup Reconcile func
 				Phase: nacv1alpha1.NonAdminPhaseNew,
 				Conditions: []metav1.Condition{
 					{
-						Type:               string(constant.NonAdminConditionAccepted),
+						Type:               string(nacv1alpha1.NonAdminConditionAccepted),
 						Status:             metav1.ConditionTrue,
 						Reason:             "BackupAccepted",
 						Message:            "backup accepted",
@@ -685,13 +685,13 @@ var _ = ginkgo.Describe("Test single reconciles of NonAdminBackup Reconcile func
 				Phase: nacv1alpha1.NonAdminPhaseCreated,
 				Conditions: []metav1.Condition{
 					{
-						Type:    string(constant.NonAdminConditionAccepted),
+						Type:    string(nacv1alpha1.NonAdminConditionAccepted),
 						Status:  metav1.ConditionTrue,
 						Reason:  "BackupAccepted",
 						Message: "backup accepted",
 					},
 					{
-						Type:    "Queued",
+						Type:    string(nacv1alpha1.NonAdminConditionQueued),
 						Status:  metav1.ConditionTrue,
 						Reason:  "BackupScheduled",
 						Message: "Created Velero Backup object",
@@ -710,7 +710,7 @@ var _ = ginkgo.Describe("Test single reconciles of NonAdminBackup Reconcile func
 				Phase: nacv1alpha1.NonAdminPhaseNew,
 				Conditions: []metav1.Condition{
 					{
-						Type:               "Accepted",
+						Type:               string(nacv1alpha1.NonAdminConditionAccepted),
 						Status:             metav1.ConditionTrue,
 						Reason:             "BackupAccepted",
 						Message:            "backup accepted",
@@ -725,13 +725,13 @@ var _ = ginkgo.Describe("Test single reconciles of NonAdminBackup Reconcile func
 				Phase: nacv1alpha1.NonAdminPhaseCreated,
 				Conditions: []metav1.Condition{
 					{
-						Type:    "Accepted",
+						Type:    string(nacv1alpha1.NonAdminConditionAccepted),
 						Status:  metav1.ConditionTrue,
 						Reason:  "BackupAccepted",
 						Message: "backup accepted",
 					},
 					{
-						Type:    "Queued",
+						Type:    string(nacv1alpha1.NonAdminConditionQueued),
 						Status:  metav1.ConditionTrue,
 						Reason:  "BackupScheduled",
 						Message: "Created Velero Backup object",
@@ -755,14 +755,14 @@ var _ = ginkgo.Describe("Test single reconciles of NonAdminBackup Reconcile func
 				VeleroBackup: &nacv1alpha1.VeleroBackup{},
 				Conditions: []metav1.Condition{
 					{
-						Type:               "Accepted",
+						Type:               string(nacv1alpha1.NonAdminConditionAccepted),
 						Status:             metav1.ConditionTrue,
 						Reason:             "BackupAccepted",
 						Message:            "backup accepted",
 						LastTransitionTime: metav1.NewTime(time.Now()),
 					},
 					{
-						Type:               "Queued",
+						Type:               string(nacv1alpha1.NonAdminConditionQueued),
 						Status:             metav1.ConditionTrue,
 						Reason:             "BackupScheduled",
 						Message:            "Created Velero Backup object",
@@ -780,13 +780,13 @@ var _ = ginkgo.Describe("Test single reconciles of NonAdminBackup Reconcile func
 				},
 				Conditions: []metav1.Condition{
 					{
-						Type:    "Accepted",
+						Type:    string(nacv1alpha1.NonAdminConditionAccepted),
 						Status:  metav1.ConditionTrue,
 						Reason:  "BackupAccepted",
 						Message: "backup accepted",
 					},
 					{
-						Type:    "Queued",
+						Type:    string(nacv1alpha1.NonAdminConditionQueued),
 						Status:  metav1.ConditionTrue,
 						Reason:  "BackupScheduled",
 						Message: "Created Velero Backup object",
@@ -809,7 +809,7 @@ var _ = ginkgo.Describe("Test single reconciles of NonAdminBackup Reconcile func
 				Phase: nacv1alpha1.NonAdminPhaseBackingOff,
 				Conditions: []metav1.Condition{
 					{
-						Type:    "Accepted",
+						Type:    string(nacv1alpha1.NonAdminConditionAccepted),
 						Status:  metav1.ConditionFalse,
 						Reason:  "InvalidBackupSpec",
 						Message: "NonAdminBackup spec.backupSpec.includedNamespaces can not contain namespaces other than:",

--- a/internal/handler/velerobackup_queue_handler.go
+++ b/internal/handler/velerobackup_queue_handler.go
@@ -74,13 +74,13 @@ func (h VeleroBackupQueueHandler) Update(ctx context.Context, evt event.UpdateEv
 			// This object is within current queue, so there is no need to trigger changes to it.
 			// The VeleroBackupHandler will serve for that.
 			if nabOriginNamespace != nabEventOriginNamespace || nabOriginName != nabEventOriginName {
-				logger.V(1).Info("Processing Queue update for the NonAdmin Backup referenced by Velero Backup", "Name", backup.Name, constant.NamespaceString, backup.Namespace, "CreatedAt", backup.CreationTimestamp)
+				logger.V(1).Info("Processing Queue update for the NonAdmin Backup referenced by Velero Backup", constant.NameString, backup.Name, constant.NamespaceString, backup.Namespace, "CreatedAt", backup.CreationTimestamp)
 				q.Add(reconcile.Request{NamespacedName: types.NamespacedName{
 					Name:      nabOriginName,
 					Namespace: nabOriginNamespace,
 				}})
 			} else {
-				logger.V(1).Info("Ignoring Queue update for the NonAdmin Backup that triggered this event", "Name", backup.Name, constant.NamespaceString, backup.Namespace, "CreatedAt", backup.CreationTimestamp)
+				logger.V(1).Info("Ignoring Queue update for the NonAdmin Backup that triggered this event", constant.NameString, backup.Name, constant.NamespaceString, backup.Namespace, "CreatedAt", backup.CreationTimestamp)
 			}
 		}
 	}


### PR DESCRIPTION
Change which moves Conditions and Phases into separate nonadmin_types.go that will be used across all other controllers within NonAdmin project. This ensures we are making them part of the API to match them closer to the design.

## Why the changes were made

<!-- Explain why this PR is important, what problems it fixes, link related issues -->

These changes were introduced to improve the consistency of the NonAdmin project by centralizing the Conditions and Phases. Moving them to a dedicated nonadmin_types.go file provides a single source of truth within API, ensuring that any controller or component working with NonAdminBackup and NonAdminRestore objects can reference these conditions and phases in a consistent way and aligned with design documents and diagrams, ensuring that they are part of the standard data structure shared across the project.

## How to test the changes made

<!-- Explain how the changes introduced by this PR can be tested and verified, with commands and pictures -->
Moving some constants and extracting common strings. Followed by running tests and linters:

```console
$ make simulation-test
$ make lint
```