### PR TITLE
Non admin status comparison against empty structure

### DIFF
--- a/internal/controller/nonadminbackup_controller.go
+++ b/internal/controller/nonadminbackup_controller.go
@@ -723,14 +723,21 @@ func updateNonAdminBackupVeleroBackupStatus(status *nacv1alpha1.NonAdminBackupSt
 	if status == nil || veleroBackup == nil {
 		return false
 	}
+
 	if status.VeleroBackup == nil {
 		status.VeleroBackup = &nacv1alpha1.VeleroBackup{}
 	}
-	if status.VeleroBackup.Status == nil || !reflect.DeepEqual(status.VeleroBackup.Status, veleroBackup.Status) {
-		status.VeleroBackup.Status = veleroBackup.Status.DeepCopy()
-		return true
+
+	if status.VeleroBackup.Status == nil {
+		status.VeleroBackup.Status = &velerov1.BackupStatus{}
 	}
-	return false
+
+	if reflect.DeepEqual(*status.VeleroBackup.Status, veleroBackup.Status) {
+		return false
+	}
+
+	status.VeleroBackup.Status = veleroBackup.Status.DeepCopy()
+	return true
 }
 
 // updateNonAdminBackupDeleteBackupRequestStatus sets the VeleroDeleteBackupRequest status field in NonAdminBackup object status and returns true
@@ -739,12 +746,19 @@ func updateNonAdminBackupDeleteBackupRequestStatus(status *nacv1alpha1.NonAdminB
 	if status == nil || veleroDeleteBackupRequest == nil {
 		return false
 	}
+
 	if status.VeleroDeleteBackupRequest == nil {
 		status.VeleroDeleteBackupRequest = &nacv1alpha1.VeleroDeleteBackupRequest{}
 	}
-	if status.VeleroDeleteBackupRequest.Status == nil || !reflect.DeepEqual(status.VeleroDeleteBackupRequest.Status, veleroDeleteBackupRequest.Status) {
-		status.VeleroDeleteBackupRequest.Status = veleroDeleteBackupRequest.Status.DeepCopy()
-		return true
+
+	if status.VeleroDeleteBackupRequest.Status == nil {
+		status.VeleroDeleteBackupRequest.Status = &velerov1.DeleteBackupRequestStatus{}
 	}
-	return false
+
+	if reflect.DeepEqual(*status.VeleroDeleteBackupRequest.Status, veleroDeleteBackupRequest.Status) {
+		return false
+	}
+
+	status.VeleroDeleteBackupRequest.Status = veleroDeleteBackupRequest.Status.DeepCopy()
+	return true
 }

--- a/internal/controller/nonadminrestore_controller.go
+++ b/internal/controller/nonadminrestore_controller.go
@@ -404,6 +404,8 @@ func (r *NonAdminRestoreReconciler) createVeleroRestore(ctx context.Context, log
 	return false, nil
 }
 
+// updateVeleroRestoreStatus sets the VeleroRestore status field in NonAdminRestore object status and returns true
+// if the VeleroRestore fields are changed by this call.
 func updateVeleroRestoreStatus(status *nacv1alpha1.NonAdminRestoreStatus, veleroRestore *velerov1.Restore) bool {
 	if status == nil || veleroRestore == nil {
 		return false
@@ -413,11 +415,16 @@ func updateVeleroRestoreStatus(status *nacv1alpha1.NonAdminRestoreStatus, velero
 		status.VeleroRestore = &nacv1alpha1.VeleroRestore{}
 	}
 
-	if status.VeleroRestore.Status == nil || !reflect.DeepEqual(status.VeleroRestore.Status, veleroRestore.Status) {
-		status.VeleroRestore.Status = veleroRestore.Status.DeepCopy()
-		return true
+	if status.VeleroRestore.Status == nil {
+		status.VeleroRestore.Status = &velerov1.RestoreStatus{}
 	}
-	return false
+
+	if reflect.DeepEqual(*status.VeleroRestore.Status, veleroRestore.Status) {
+		return false
+	}
+
+	status.VeleroRestore.Status = veleroRestore.Status.DeepCopy()
+	return true
 }
 
 // SetupWithManager sets up the controller with the Manager.


### PR DESCRIPTION
Change implementation of the status functions to ensure that an empty status is properly compared against an empty structure, treating it as equivalent to nil

Previous implementation had corner case where reconcile would lead to unnecessary updates, even both statuses were effectively "empty".

## Why the changes were made

<!-- Explain why this PR is important, what problems it fixes, link related issues -->
To fix reconcile updates to the status where the status should not be updated.

## How to test the changes made

<!-- Explain how the changes introduced by this PR can be tested and verified, with commands and pictures -->
Fix logic observed during controller manual testing.