### PR TITLE
Modify the Non Admin Backup API deletion to align with sync controller

### DIFF
--- a/api/v1alpha1/nonadminbackup_types.go
+++ b/api/v1alpha1/nonadminbackup_types.go
@@ -30,11 +30,6 @@ type NonAdminBackupSpec struct {
 	// as well as the corresponding object storage
 	// +optional
 	DeleteBackup bool `json:"deleteBackup,omitempty"`
-
-	// ForceDeleteBackup removes the NonAdminBackup and its associated VeleroBackup from the cluster,
-	// regardless of whether deletion from object storage succeeds or fails
-	// +optional
-	ForceDeleteBackup bool `json:"forceDeleteBackup,omitempty"`
 }
 
 // VeleroBackup contains information of the related Velero backup object.

--- a/config/crd/bases/oadp.openshift.io_nonadminbackups.yaml
+++ b/config/crd/bases/oadp.openshift.io_nonadminbackups.yaml
@@ -526,11 +526,6 @@ spec:
                   DeleteBackup removes the NonAdminBackup and its associated VeleroBackup from the cluster,
                   as well as the corresponding object storage
                 type: boolean
-              forceDeleteBackup:
-                description: |-
-                  ForceDeleteBackup removes the NonAdminBackup and its associated VeleroBackup from the cluster,
-                  regardless of whether deletion from object storage succeeds or fails
-                type: boolean
             required:
             - backupSpec
             type: object

--- a/docs/design/nab_and_nar_status_update.md
+++ b/docs/design/nab_and_nar_status_update.md
@@ -260,10 +260,13 @@ flowchart TD
     NAB_API_DELETE --> setPhase["NAB Phase: **Deleting**"]
     setPhase --> setCondition["NAB Condition: Deleting=True
     Reason: DeletionPending
-    Message: backup deletion requires setting
-    spec.deleteBackup or spec.forceDeleteBackup
-    to true or finalizer removal"]
-    setCondition -->|Update Status if Changed<br>▶ Continue ║No Requeue║| endDelete["End"]
+    Message: permanent backup deletion requires
+    setting spec.deleteBackup to true"]
+    setCondition -->|Update Status if Changed<br>▶ Continue ║No Requeue║| checkVeleroBackupObjects
+    checkVeleroBackupObjects{Check VeleroBackup} -->|Exist| deleteVeleroBackupObjects[Delete VeleroBackup Objects]
+    deleteVeleroBackupObjects --> removeApiDeleteFinalizer[Remove NAB Finalizer]
+    checkVeleroBackupObjects -->|Don't Exist| removeApiDeleteFinalizer
+    removeApiDeleteFinalizer --> endDelete["End API Delete"]
 
     %% Force Delete Path
     FORCE_DELETE --> setDeletingPhase[NAB Phase: **Deleting**]
@@ -327,12 +330,12 @@ flowchart TD
     classDef waitState fill:#ccccff,stroke:#333,stroke-width:2px
 
     %% Apply styles to all nodes
-    class SWITCH,initNabCreate,validateSpec,setFinalizer,createVB,checkVeleroBackup,validateDelete,checkDeletionTimestamp,checkDeletionTimestampDelete,checkRequeueFlagDelete,checkVeleroObjects,checkRequeueFlag,checkStatusChanged,checkStatusChangedDelete,checkDeleteBackupRequest decision
-    class start,CREATE_UPDATE,NAB_API_DELETE,FORCE_DELETE,DELETE_BACKUP,generateNACUUID,createNewVB,removeBackup,initiateForceDelete,deleteVeleroObjects,initiateDelete process
+    class SWITCH,initNabCreate,validateSpec,setFinalizer,createVB,checkVeleroBackup,validateDelete,checkDeletionTimestamp,checkDeletionTimestampDelete,checkRequeueFlagDelete,checkVeleroObjects,checkRequeueFlag,checkStatusChanged,checkStatusChangedDelete,checkDeleteBackupRequest,checkVeleroBackupObjects decision
+    class start,CREATE_UPDATE,NAB_API_DELETE,FORCE_DELETE,DELETE_BACKUP,generateNACUUID,createNewVB,removeBackup,initiateForceDelete,deleteVeleroObjects,deleteVeleroBackupObjects,initiateDelete process
     class terminalError,endCreateUpdate,endDelete,endForce,endDeleteBackup endpoint
     class setNewPhase,setBackingOffPhase,setCreatedPhase,setPhase,setDeletePhase,setDeletionPhase,setDeletingPhase,setDeletingPhaseDelete phase
     class setInitialCondition,setInvalidCondition,setAcceptedCondition,setQueuedCondition,setCondition,setDeletingCondition,setDeletingConditionDelete condition
-    class updateFromVB,updateNABStatus,addFinalizer,removeFinalizer update
+    class updateFromVB,updateNABStatus,addFinalizer,removeFinalizer,removeApiDeleteFinalizer update
     class refetchNAB refetch
     class setDeleteStatus,createDBR,updateStatus deleteProcess
     class waitForDeletion waitState

--- a/internal/controller/nonadminbackup_controller.go
+++ b/internal/controller/nonadminbackup_controller.go
@@ -96,10 +96,15 @@ func (r *NonAdminBackupReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 	switch {
 	case nab.Spec.ForceDeleteBackup:
 		// Force delete path - immediately removes both VeleroBackup and DeleteBackupRequest
+		// Remove dependent VeleroBackup object
+		// Remove finalizer from the NonAdminBackup object
+		// If there was existing BSL pointing to the Backup object
+		// the Backup will be restored causing the NAB to be recreated
 		logger.V(1).Info("Executing force delete path")
 		reconcileSteps = []nonAdminBackupReconcileStepFunction{
 			r.setStatusAndConditionForDeletionAndCallDelete,
-			r.deleteVeleroBackupAndDeleteBackupRequestObjects,
+			r.deleteVeleroBackupObjects,
+			r.deleteDeleteBackupRequestObjects,
 			r.removeNabFinalizerUponVeleroBackupDeletion,
 		}
 
@@ -114,11 +119,15 @@ func (r *NonAdminBackupReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 
 	case !nab.ObjectMeta.DeletionTimestamp.IsZero():
 		// Direct deletion path - sets status and condition
-		// Initializes deletion of the NonAdminBackup object without removing
-		// dependent VeleroBackup object
+		// Remove dependent VeleroBackup object
+		// Remove finalizer from the NonAdminBackup object
+		// If there was existing BSL pointing to the Backup object
+		// the Backup will be restored causing the NAB to be recreated
 		logger.V(1).Info("Executing direct deletion path")
 		reconcileSteps = []nonAdminBackupReconcileStepFunction{
 			r.setStatusForDirectKubernetesAPIDeletion,
+			r.deleteVeleroBackupObjects,
+			r.removeNabFinalizerUponVeleroBackupDeletion,
 		}
 
 	default:
@@ -211,7 +220,7 @@ func (r *NonAdminBackupReconciler) setStatusForDirectKubernetesAPIDeletion(ctx c
 			Type:    string(nacv1alpha1.NonAdminConditionDeleting),
 			Status:  metav1.ConditionTrue,
 			Reason:  "DeletionPending",
-			Message: "backup deletion requires setting spec.deleteBackup or spec.forceDeleteBackup to true or finalizer removal",
+			Message: "permanent backup deletion requires setting spec.deleteBackup to true",
 		},
 	)
 	if updatedPhase || updatedCondition {
@@ -320,8 +329,8 @@ func (r *NonAdminBackupReconciler) createVeleroDeleteBackupRequest(ctx context.C
 	return false, nil // Continue so initNabDeletion can initialize deletion of a NonAdminBackup object
 }
 
-// deleteVeleroBackupAndDeleteBackupRequestObjects deletes both the VeleroBackup and any associated
-// DeleteBackupRequest objects for a given NonAdminBackup when force deletion is requested.
+// deleteVeleroBackupObjects deletes the VeleroBackup objects
+// associated with a given NonAdminBackup
 //
 // Parameters:
 //   - ctx: Context for managing request lifetime
@@ -331,9 +340,9 @@ func (r *NonAdminBackupReconciler) createVeleroDeleteBackupRequest(ctx context.C
 // Returns:
 //   - bool: whether to requeue (always false)
 //   - error: any error encountered during deletion
-func (r *NonAdminBackupReconciler) deleteVeleroBackupAndDeleteBackupRequestObjects(ctx context.Context, logger logr.Logger, nab *nacv1alpha1.NonAdminBackup) (bool, error) {
-	// This function is called just after setStatusAndConditionForDeletionAndCallDelete - force delete path, which already
-	// requeued the reconciliation to get the latest NAB object. There is no need to fetch the latest NAB object here.
+func (r *NonAdminBackupReconciler) deleteVeleroBackupObjects(ctx context.Context, logger logr.Logger, nab *nacv1alpha1.NonAdminBackup) (bool, error) {
+	// This function is called in a workflows where requeue just happened.
+	// There is no need to fetch the latest NAB object here.
 	if nab.Status.VeleroBackup == nil || nab.Status.VeleroBackup.NACUUID == constant.EmptyString {
 		return false, nil
 	}
@@ -358,6 +367,27 @@ func (r *NonAdminBackupReconciler) deleteVeleroBackupAndDeleteBackupRequestObjec
 		logger.V(1).Info("VeleroBackup already deleted")
 	}
 
+	return false, nil
+}
+
+// deleteDeleteBackupRequestObjects deletes the VeleroBackup DeleteBackupRequestObjects
+// associated with a given NonAdminBackup
+//
+// Parameters:
+//   - ctx: Context for managing request lifetime
+//   - logger: Logger instance
+//   - nab: NonAdminBackup object
+//
+// Returns:
+//   - bool: whether to requeue (always false)
+//   - error: any error encountered during deletion
+func (r *NonAdminBackupReconciler) deleteDeleteBackupRequestObjects(ctx context.Context, logger logr.Logger, nab *nacv1alpha1.NonAdminBackup) (bool, error) {
+	// There is no need to fetch the latest NAB object here.
+	if nab.Status.VeleroBackup == nil || nab.Status.VeleroBackup.NACUUID == constant.EmptyString {
+		return false, nil
+	}
+
+	veleroBackupNACUUID := nab.Status.VeleroBackup.NACUUID
 	deleteBackupRequest, err := function.GetVeleroDeleteBackupRequestByLabel(ctx, r.Client, r.OADPNamespace, veleroBackupNACUUID)
 	if err != nil {
 		// Log error if multiple DeleteBackupRequest objects are found


### PR DESCRIPTION
Non Admin Backup delete event should remove corresponding Velero Backup

This allows Velero Sync controller to recreate Velero Backup object and cascate such recreation back to the Non Admin Backup. The cascade action is a responsibility of an Non Admin Sync controller.

## Why the changes were made

Those changes are made to allow sync controller that is implemented as part of the #38 implemented by #138 to recreate Non Admin Backup in unified way, meaning it will be recreated on the new Velero Backup recreation by the Velero Sync controller.

In other words with this behavior when user runs:
```shell
$ oc delete <non-admin-backup> -n mynamespace
```

This will result in removal of associated Velero Backup (if was existing) and then removal of NAB finalizer.
Such action will cause s3 storage to still have the information about the Velero Backup, because the removal was not done via spec field and no DeleteBackupRequest was created.
With the s3 storage containing information about Velero Backup, the Velero Sync Controller will recreate the Velero Backup object in the `openshift-adp` namespace. That event should trigger Non Admin Backup Sync Controller implemented as part of the #138 to recreate Non Admin Backup in the user's namespace.

## How to test the changes made

<!-- Explain how the changes introduced by this PR can be tested and verified, with commands and pictures -->

e2e tests were written, run simulation tests
