### PR TITLE
Fix CI job for manifest check between oadp and non admin

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,12 +73,13 @@ jobs:
       - name: Checkout OADP operator
         uses: actions/checkout@v4
         with:
+          path: oadp-operator
           repository: openshift/oadp-operator
           ref: ${{ github.base_ref || github.ref_name }}
 
       - uses: actions/setup-go@v5
         with:
-          go-version-file: go.mod
+          go-version-file: ./oadp-operator/go.mod
           cache: false
 
       - name: Checkout Non Admin Controller (NAC)
@@ -87,8 +88,9 @@ jobs:
           path: oadp-non-admin
 
       - name: Check Non Admin Controller (NAC) manifests
+        working-directory: ./oadp-operator
         run: |
-          NON_ADMIN_CONTROLLER_PATH=./oadp-non-admin make update-non-admin-manifests
+          NON_ADMIN_CONTROLLER_PATH=../oadp-non-admin make update-non-admin-manifests
           if test -n "$(git status --short -- ':!oadp-non-admin')"; then
             echo "::error::run 'make update-non-admin-manifests' in OADP repository to update Non Admin Controller (NAC) manifests"
             exit 1
@@ -97,7 +99,7 @@ jobs:
       - name: Check Velero manifests
         working-directory: ./oadp-non-admin
         run: |
-          OADP_OPERATOR_PATH=../ make update-velero-manifests
+          OADP_OPERATOR_PATH=../oadp-operator make update-velero-manifests
           if test -n "$(git status --short)"; then
             echo "::error::run 'make update-velero-manifests' in Non Admin Controller (NAC) repository to update Velero manifests"
             exit 1


### PR DESCRIPTION
Fixes problem with the make bundle that was using rbac from subfolder.

## Why the changes were made

<!-- Explain why this PR is important, what problems it fixes, link related issues -->
To fix the CI job that checks the operator manifests.

## How to test the changes made

<!-- Explain how the changes introduced by this PR can be tested and verified, with commands and pictures -->
By allowing the github action to pass.