### PR TITLE
Add Debug Information Paths to NAB/NAR CR status

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,6 @@ go.work
 *.swp
 *.swo
 *~
+
+# artifacts generated when debugging
+debug.*

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,7 @@ RUN go mod download
 COPY cmd/main.go cmd/main.go
 COPY api/ api/
 COPY internal/ internal/
+COPY pkg/ pkg/
 
 # Build
 # the GOARCH has not a default value to allow the binary be built according to the host where the command

--- a/Makefile
+++ b/Makefile
@@ -65,6 +65,10 @@ vet: ## Run go vet against code.
 test: manifests generate fmt vet envtest ## Run tests.
 	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" go test $$(go list ./... | grep -v /e2e) -coverprofile cover.out
 
+# Generates kubebuilder assets dir to assist running test in IDEs which would not call `use` on envtest to create assets required for for suite_test
+generate-kubebuilder_assets: envtest
+	$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)
+
 # Utilize Kind or modify the e2e tests to load the image locally, enabling compatibility with other vendors.
 .PHONY: test-e2e  # Run the e2e tests against a Kind k8s instance that is spun up.
 test-e2e:

--- a/api/v1alpha1/nonadminbackup_types.go
+++ b/api/v1alpha1/nonadminbackup_types.go
@@ -88,6 +88,12 @@ type NonAdminBackupStatus struct {
 	// phase is a simple one high-level summary of the lifecycle of an NonAdminBackup.
 	Phase NonAdminPhase `json:"phase,omitempty"`
 
+	// logsPath is path to backup logs in the storage location
+	LogsPath string `json:"logsPath,omitempty"`
+
+	// resourceListPath is path to resource list of backup in storage location
+	ResourceListPath string `json:"resourceListPath,omitempty"`
+
 	Conditions []metav1.Condition `json:"conditions,omitempty"`
 }
 

--- a/api/v1alpha1/nonadminrestore_types.go
+++ b/api/v1alpha1/nonadminrestore_types.go
@@ -61,6 +61,12 @@ type NonAdminRestoreStatus struct {
 	// phase is a simple one high-level summary of the lifecycle of an NonAdminRestore.
 	Phase NonAdminPhase `json:"phase,omitempty"`
 
+	// logsPath is path to backup logs in the storage location
+	LogsPath string `json:"logsPath,omitempty"`
+
+	// resourceListPath is path to resource list of backup in storage location
+	ResourceListPath string `json:"resourceListPath,omitempty"`
+
 	Conditions []metav1.Condition `json:"conditions,omitempty"`
 }
 

--- a/api/v1alpha1/nonadminrestore_types.go
+++ b/api/v1alpha1/nonadminrestore_types.go
@@ -61,10 +61,10 @@ type NonAdminRestoreStatus struct {
 	// phase is a simple one high-level summary of the lifecycle of an NonAdminRestore.
 	Phase NonAdminPhase `json:"phase,omitempty"`
 
-	// logsPath is path to backup logs in the storage location
+	// logsPath is path to restore logs in the storage location
 	LogsPath string `json:"logsPath,omitempty"`
 
-	// resourceListPath is path to resource list of backup in storage location
+	// resourceListPath is path to resource list of restore in storage location
 	ResourceListPath string `json:"resourceListPath,omitempty"`
 
 	Conditions []metav1.Condition `json:"conditions,omitempty"`

--- a/config/crd/bases/oadp.openshift.io_nonadminbackups.yaml
+++ b/config/crd/bases/oadp.openshift.io_nonadminbackups.yaml
@@ -601,6 +601,9 @@ spec:
                   - type
                   type: object
                 type: array
+              logsPath:
+                description: logsPath is path to backup logs in the storage location
+                type: string
               phase:
                 description: phase is a simple one high-level summary of the lifecycle
                   of an NonAdminBackup.
@@ -624,6 +627,10 @@ spec:
                 required:
                 - estimatedQueuePosition
                 type: object
+              resourceListPath:
+                description: resourceListPath is path to resource list of backup in
+                  storage location
+                type: string
               veleroBackup:
                 description: VeleroBackup contains information of the related Velero
                   backup object.

--- a/config/crd/bases/oadp.openshift.io_nonadminrestores.yaml
+++ b/config/crd/bases/oadp.openshift.io_nonadminrestores.yaml
@@ -534,6 +534,9 @@ spec:
                   - type
                   type: object
                 type: array
+              logsPath:
+                description: logsPath is path to backup logs in the storage location
+                type: string
               phase:
                 description: phase is a simple one high-level summary of the lifecycle
                   of an NonAdminRestore.
@@ -557,6 +560,10 @@ spec:
                 required:
                 - estimatedQueuePosition
                 type: object
+              resourceListPath:
+                description: resourceListPath is path to resource list of backup in
+                  storage location
+                type: string
               veleroRestore:
                 description: VeleroRestore contains information of the related Velero
                   restore object.

--- a/config/crd/bases/oadp.openshift.io_nonadminrestores.yaml
+++ b/config/crd/bases/oadp.openshift.io_nonadminrestores.yaml
@@ -535,7 +535,7 @@ spec:
                   type: object
                 type: array
               logsPath:
-                description: logsPath is path to backup logs in the storage location
+                description: logsPath is path to restore logs in the storage location
                 type: string
               phase:
                 description: phase is a simple one high-level summary of the lifecycle
@@ -561,8 +561,8 @@ spec:
                 - estimatedQueuePosition
                 type: object
               resourceListPath:
-                description: resourceListPath is path to resource list of backup in
-                  storage location
+                description: resourceListPath is path to resource list of restore
+                  in storage location
                 type: string
               veleroRestore:
                 description: VeleroRestore contains information of the related Velero

--- a/docs/design/Debug_DownloadURL.md
+++ b/docs/design/Debug_DownloadURL.md
@@ -1,0 +1,207 @@
+# Debug content Download URL Exposure Design
+
+<!-- _Note_: The preferred style for design documents is one sentence per line.
+*Do not wrap lines*.
+This aids in review of the document as changes to a line are not obscured by the reflowing those changes caused and has a side effect of avoiding debate about one or two space after a period. -->
+
+## Abstract
+
+We want to provide a way for Non Admins (NAs) to debug their non admin backup (NAB) and/or non admin restore (NAR).
+
+## Background
+
+A backup/restore operation may not always succeed in part, or in full. Non Admin User would like a way to diagnose their backup or restore based on information available on object store uploaded by Velero during its backup or restore process.
+
+## Goals
+
+- Provide a path or url to debug information on NAB and NAR statuses, allowing credentialed object store users to access debug information.
+
+## Non Goals
+
+- Create a CLI
+- Automatically retrieve debug information on behalf of the user
+
+## High-Level Design
+
+When a NAC velero backup or restore is completed, its associated NAB/NAR are updated to completion status.
+
+During this time, NAC will also inject into status a path (ie. S3 url) to a relevant debugging file on the storage location that velero had uploaded.
+
+## Detailed Design
+
+[Currently](https://github.com/vmware-tanzu/velero/blob/2197cab3dbf1038b7afe363284d7b9e18c9300dc/pkg/apis/velero/v1/download_request_types.go#L32-L45) velero exposes following DownloadTargetKind that can be used in a DownloadRequest spec.
+
+```go
+ DownloadTargetKindBackupLog                       DownloadTargetKind = "BackupLog"
+ DownloadTargetKindBackupContents                  DownloadTargetKind = "BackupContents"
+ DownloadTargetKindBackupVolumeSnapshots           DownloadTargetKind = "BackupVolumeSnapshots"
+ DownloadTargetKindBackupItemOperations            DownloadTargetKind = "BackupItemOperations"
+ DownloadTargetKindBackupResourceList              DownloadTargetKind = "BackupResourceList"
+ DownloadTargetKindBackupResults                   DownloadTargetKind = "BackupResults"
+ DownloadTargetKindRestoreLog                      DownloadTargetKind = "RestoreLog"
+ DownloadTargetKindRestoreResults                  DownloadTargetKind = "RestoreResults"
+ DownloadTargetKindRestoreResourceList             DownloadTargetKind = "RestoreResourceList"
+ DownloadTargetKindRestoreItemOperations           DownloadTargetKind = "RestoreItemOperations"
+ DownloadTargetKindCSIBackupVolumeSnapshots        DownloadTargetKind = "CSIBackupVolumeSnapshots"
+ DownloadTargetKindCSIBackupVolumeSnapshotContents DownloadTargetKind = "CSIBackupVolumeSnapshotContents"
+ DownloadTargetKindBackupVolumeInfos               DownloadTargetKind = "BackupVolumeInfos"
+ DownloadTargetKindRestoreVolumeInfo               DownloadTargetKind = "RestoreVolumeInfo"
+```
+
+These are the expected kinds of items we can get from object store for debugging.
+
+The path to these items in an object store is defined in [pkg/persistence/object_store_layout.go](https://github.com/vmware-tanzu/velero/blob/0a280e57863c70495a2dfb65787615a68a0e7b03/pkg/persistence/object_store_layout.go) of velero repo.
+
+We will use this knowledge to populate NAB/NAR status fields with path to log and resourceList.
+
+In the future we may have a CLI that can gather resources available in DownloadTargetKind using the values added to NAB/NAR statuses from this enhancement.
+
+### Usage examples
+
+In a completed NAB, you see in its status.resourceListPath has a value of `s3://velero-6109f5e9711c8c58131acdd2f490f451/velero-e2e-00093375-ecd8-41d8-81fc-8ce9d4983ad6/backups/mongo-blockdevice-e2e-f26ab76c-34d1-11ef-93a5-0a580a834d36/mongo-blockdevice-e2e-f26ab76c-34d1-11ef-93a5-0a580a834d36-resource-list.json.gz`
+
+Given a user have credentials to the object storage, they will be able to run following commands to get resource lists in the backup.
+```
+❯ aws s3 cp s3://velero-6109f5e9711c8c58131acdd2f490f451/velero-e2e-00093375-ecd8-41d8-81fc-8ce9d4983ad6/backups/mongo-blockdevice-e2e-f26ab76c-34d1-11ef-93a5-0a580a834d36/mongo-blockdevice-e2e-f26ab76c-34d1-11ef-93a5-0a580a834d36-resource-list.json.gz .
+
+❯ gzip --uncompress --to-stdout mongo-blockdevice-e2e-f26ab76c-34d1-11ef-93a5-0a580a834d36-resource-list.json.gz | jq
+{
+  "apps.openshift.io/v1/DeploymentConfig": [
+    "mongo-persistent/todolist"
+  ],
+  "apps/v1/Deployment": [
+    "mongo-persistent/mongo"
+  ],
+  "apps/v1/ReplicaSet": [
+    "mongo-persistent/mongo-7645dc59b7"
+  ],
+  "authorization.openshift.io/v1/RoleBinding": [
+    "mongo-persistent/system:deployers",
+    "mongo-persistent/system:image-builders",
+    "mongo-persistent/system:image-pullers"
+  ],
+  "discovery.k8s.io/v1/EndpointSlice": [
+    "mongo-persistent/mongo-hf89b",
+    "mongo-persistent/todolist-frpft"
+  ],
+  "image.openshift.io/v1/ImageStream": [
+    "mongo-persistent/todolist-mongo-go"
+  ],
+  "rbac.authorization.k8s.io/v1/RoleBinding": [
+    "mongo-persistent/system:deployers",
+    "mongo-persistent/system:image-builders",
+    "mongo-persistent/system:image-pullers"
+  ],
+  "route.openshift.io/v1/Route": [
+    "mongo-persistent/todolist-route"
+  ],
+  "security.openshift.io/v1/SecurityContextConstraints": [
+    "mongo-persistent-scc"
+  ],
+  "v1/ConfigMap": [
+    "mongo-persistent/kube-root-ca.crt",
+    "mongo-persistent/openshift-service-ca.crt"
+  ],
+  "v1/Endpoints": [
+    "mongo-persistent/mongo",
+    "mongo-persistent/todolist"
+  ],
+  "v1/Event": [
+    "mongo-persistent/mongo-7645dc59b7-ddnpr.17dcfbf31d2411b3",
+    "mongo-persistent/mongo-7645dc59b7-ddnpr.17dcfbf45c7ee237",
+    "mongo-persistent/mongo-7645dc59b7-ddnpr.17dcfbf4ecd8fb4f",
+    "mongo-persistent/mongo-7645dc59b7-ddnpr.17dcfbf4fc16952d",
+    "mongo-persistent/mongo-7645dc59b7-ddnpr.17dcfbf4fc16e3bc",
+    "mongo-persistent/mongo-7645dc59b7-ddnpr.17dcfbf518b65eac",
+    "mongo-persistent/mongo-7645dc59b7-ddnpr.17dcfbf51a288d26",
+    "mongo-persistent/mongo-7645dc59b7-ddnpr.17dcfbf5215c6989",
+    "mongo-persistent/mongo-7645dc59b7-ddnpr.17dcfbf526ddd2e3",
+    "mongo-persistent/mongo-7645dc59b7-ddnpr.17dcfbf527b6e869",
+    "mongo-persistent/mongo-7645dc59b7-ddnpr.17dcfbf5499768e5",
+    "mongo-persistent/mongo-7645dc59b7-ddnpr.17dcfbf550e736c1",
+    "mongo-persistent/mongo-7645dc59b7-ddnpr.17dcfbf556dbbde4",
+    "mongo-persistent/mongo-7645dc59b7-ddnpr.17dcfbf557a59c91",
+    "mongo-persistent/mongo-7645dc59b7.17dcfbf31d2357e0",
+    "mongo-persistent/mongo.17dcfbf31911596c",
+    "mongo-persistent/mongo.17dcfbf32101157f",
+    "mongo-persistent/mongo.17dcfbf36dcc9869",
+    "mongo-persistent/mongo.17dcfbf36dd6c3b0",
+    "mongo-persistent/mongo.17dcfbf439418098",
+    "mongo-persistent/todolist-1-deploy.17dcfbf32432b1f8",
+    "mongo-persistent/todolist-1-deploy.17dcfbf35206b4ea",
+    "mongo-persistent/todolist-1-deploy.17dcfbf353d7fdbf",
+    "mongo-persistent/todolist-1-deploy.17dcfbf358a11021",
+    "mongo-persistent/todolist-1-deploy.17dcfbf3598d5f3d",
+    "mongo-persistent/todolist-1-wqhpb.17dcfbf35f204990",
+    "mongo-persistent/todolist-1-wqhpb.17dcfbf38b531ba6",
+    "mongo-persistent/todolist-1-wqhpb.17dcfbf38c971e09",
+    "mongo-persistent/todolist-1-wqhpb.17dcfbf3919831c9",
+    "mongo-persistent/todolist-1-wqhpb.17dcfbf3927a3b4e",
+    "mongo-persistent/todolist-1-wqhpb.17dcfbfcfd3a2577",
+    "mongo-persistent/todolist-1-wqhpb.17dcfbfd07869b18",
+    "mongo-persistent/todolist-1-wqhpb.17dcfbfd0ca71c96",
+    "mongo-persistent/todolist-1-wqhpb.17dcfbfd0da3efdc",
+    "mongo-persistent/todolist-1.17dcfbf35ebded07",
+    "mongo-persistent/todolist.17dcfbf320766931"
+  ],
+  "v1/Namespace": [
+    "mongo-persistent"
+  ],
+  "v1/PersistentVolume": [
+    "pvc-2c2ff5b8-3b06-467c-8b0e-99a40cde4993"
+  ],
+  "v1/PersistentVolumeClaim": [
+    "mongo-persistent/mongo"
+  ],
+  "v1/Pod": [
+    "mongo-persistent/mongo-7645dc59b7-ddnpr",
+    "mongo-persistent/todolist-1-deploy",
+    "mongo-persistent/todolist-1-wqhpb"
+  ],
+  "v1/ReplicationController": [
+    "mongo-persistent/todolist-1"
+  ],
+  "v1/Secret": [
+    "mongo-persistent/builder-dockercfg-h7p9c",
+    "mongo-persistent/builder-token-l79l7",
+    "mongo-persistent/default-dockercfg-nnjfj",
+    "mongo-persistent/default-token-7d745",
+    "mongo-persistent/deployer-dockercfg-dvrn8",
+    "mongo-persistent/deployer-token-dl9m2",
+    "mongo-persistent/mongo-persistent-sa-dockercfg-p9zfk",
+    "mongo-persistent/mongo-persistent-sa-token-55qxx"
+  ],
+  "v1/Service": [
+    "mongo-persistent/mongo",
+    "mongo-persistent/todolist"
+  ],
+  "v1/ServiceAccount": [
+    "mongo-persistent/builder",
+    "mongo-persistent/default",
+    "mongo-persistent/deployer",
+    "mongo-persistent/mongo-persistent-sa"
+  ]
+}
+```
+
+## Alternatives Considered
+
+Generating a short lived signed url
+
+- While this approach do not require user to have bucket credentials, the URL retrieved will be short lived such that it will only be practical to use if programmatically used by a CLI, which is out of scope of current design.
+
+## Security Considerations
+
+We will assume that user who have object store credentials are the authorized personnel to access this data path and the object store bucket as a whole.
+Other users who share this bucket are also assumed to be similarly privileged and have access to all other shared users data in the object store.
+
+## Compatibility
+
+A new status field(s) will need to be added to NAB/NAR to expose debug info path.
+This includes updates to the CRD within oadp-operator project as well.
+
+## Implementation
+<!-- A description of the implementation, timelines, and any resources that have agreed to contribute. -->
+
+## Open Issues
+<!-- A discussion of issues relating to this proposal for which the author does not know the solution. This section may be omitted if there are none. -->

--- a/internal/controller/nonadminbackup_controller.go
+++ b/internal/controller/nonadminbackup_controller.go
@@ -632,13 +632,14 @@ func (r *NonAdminBackupReconciler) createVeleroBackupAndSyncWithNonAdminBackup(c
 		// Included Namespaces are set by the controller and can not be overridden by the user
 		// nor admin user
 		backupSpec.IncludedNamespaces = []string{nab.Namespace}
+		// If not empty, has to be a NaBSL, so override to a NaBSL with that name.
 		if backupSpec.StorageLocation != constant.EmptyString {
 			nonAdminBsl := &nacv1alpha1.NonAdminBackupStorageLocation{}
 
 			if nabslErr := r.Client.Get(ctx, types.NamespacedName{Name: backupSpec.StorageLocation, Namespace: nab.Namespace}, nonAdminBsl); nabslErr != nil {
 				return false, nabslErr
 			}
-			// Should there be a warning that we are overriding the user's storage location?
+
 			backupSpec.StorageLocation = nonAdminBsl.Status.VeleroBackupStorageLocation.Name
 		}
 

--- a/internal/controller/nonadminbackup_controller.go
+++ b/internal/controller/nonadminbackup_controller.go
@@ -638,7 +638,7 @@ func (r *NonAdminBackupReconciler) createVeleroBackupAndSyncWithNonAdminBackup(c
 			if nabslErr := r.Client.Get(ctx, types.NamespacedName{Name: backupSpec.StorageLocation, Namespace: nab.Namespace}, nonAdminBsl); nabslErr != nil {
 				return false, nabslErr
 			}
-
+			// Should there be a warning that we are overriding the user's storage location?
 			backupSpec.StorageLocation = nonAdminBsl.Status.VeleroBackupStorageLocation.Name
 		}
 

--- a/internal/controller/nonadminbackup_controller_test.go
+++ b/internal/controller/nonadminbackup_controller_test.go
@@ -1099,7 +1099,7 @@ var _ = ginkgo.Describe("Test full reconcile loop of NonAdminBackup Controller",
 				},
 			}
 			gomega.Expect(k8sClient.Status().Update(ctxTimeout, nonAdminBackupStorageLocation)).To(gomega.Succeed())
-			
+
 			// wait NAB reconcile
 			time.Sleep(2 * time.Second)
 

--- a/internal/controller/nonadminbackup_controller_test.go
+++ b/internal/controller/nonadminbackup_controller_test.go
@@ -977,7 +977,7 @@ var _ = ginkgo.Describe("Test single reconciles of NonAdminBackup Reconcile func
 func testStorageLocation(name, namespace, provider, bucket, prefix string) velerov1.BackupStorageLocation {
 	return velerov1.BackupStorageLocation{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: name,
+			Name:      name,
 			Namespace: namespace,
 		},
 		Spec: velerov1.BackupStorageLocationSpec{
@@ -1076,7 +1076,7 @@ var _ = ginkgo.Describe("Test full reconcile loop of NonAdminBackup Controller",
 			if scenario.enforcedBackupSpec != nil {
 				scenario.enforcedBackupSpec.StorageLocation = testBSL.Name
 			}
-			
+
 			gomega.Expect(k8sClient.Create(ctxTimeout, nonAdminBackup)).To(gomega.Succeed())
 			// wait NAB reconcile
 			time.Sleep(2 * time.Second)
@@ -1151,7 +1151,13 @@ var _ = ginkgo.Describe("Test full reconcile loop of NonAdminBackup Controller",
 					return nonAdminBackup.Status.VeleroBackup.Status.Phase == velerov1.BackupPhaseCompleted, nil
 				}, 5*time.Second, 1*time.Second).Should(gomega.BeTrue())
 			}
-
+			if nonAdminBackup != nil &&
+				nonAdminBackup.Status.VeleroBackup != nil &&
+				nonAdminBackup.Status.VeleroBackup.Status != nil &&
+				nonAdminBackup.Status.VeleroBackup.Status.Phase == velerov1.BackupPhaseCompleted {
+				gomega.Expect(nonAdminBackup.Status.LogsPath).To(gomega.Not(gomega.BeZero()))
+				gomega.Expect(nonAdminBackup.Status.ResourceListPath).To(gomega.Not(gomega.BeZero()))
+			}
 			ginkgo.By("Waiting Reconcile of delete event")
 			gomega.Expect(k8sClient.Delete(ctxTimeout, nonAdminBackup)).To(gomega.Succeed())
 			time.Sleep(1 * time.Second)

--- a/internal/controller/nonadminbackup_controller_test.go
+++ b/internal/controller/nonadminbackup_controller_test.go
@@ -973,7 +973,9 @@ var _ = ginkgo.Describe("Test single reconciles of NonAdminBackup Reconcile func
 			resultError: reconcile.TerminalError(fmt.Errorf("NonAdminBackup spec.backupSpec.includedNamespaces can not contain namespaces other than: ")),
 		}))
 })
+
 const testuuid = "test-uuid"
+
 func testStorageLocation(name, namespace, uuid, provider, bucket, prefix string) velerov1.BackupStorageLocation {
 	return velerov1.BackupStorageLocation{
 		ObjectMeta: metav1.ObjectMeta{
@@ -1083,7 +1085,7 @@ var _ = ginkgo.Describe("Test full reconcile loop of NonAdminBackup Controller",
 			// so create one
 			nonAdminBackupStorageLocation := &nacv1alpha1.NonAdminBackupStorageLocation{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: nonAdminBackup.Spec.BackupSpec.StorageLocation,
+					Name:      nonAdminBackup.Spec.BackupSpec.StorageLocation,
 					Namespace: nonAdminBackup.Namespace,
 				},
 				Spec: nacv1alpha1.NonAdminBackupStorageLocationSpec{
@@ -1095,7 +1097,7 @@ var _ = ginkgo.Describe("Test full reconcile loop of NonAdminBackup Controller",
 			nonAdminBackupStorageLocation.Status = nacv1alpha1.NonAdminBackupStorageLocationStatus{
 				VeleroBackupStorageLocation: &nacv1alpha1.VeleroBackupStorageLocation{
 					NACUUID: testuuid,
-					Name: testBSL.Name,
+					Name:    testBSL.Name,
 				},
 			}
 			gomega.Expect(k8sClient.Status().Update(ctxTimeout, nonAdminBackupStorageLocation)).To(gomega.Succeed())

--- a/internal/controller/nonadminrestore_controller_test.go
+++ b/internal/controller/nonadminrestore_controller_test.go
@@ -213,7 +213,7 @@ var _ = ginkgo.Describe("Test full reconcile loop of NonAdminRestore Controller"
 						CompletionTimestamp: &metav1.Time{Time: time.Now()},
 					},
 				}
-				err := k8sClient.Create(context.Background(), &veleroBackup)
+				err = k8sClient.Create(context.Background(), &veleroBackup)
 				gomega.Expect(err).ToNot(gomega.HaveOccurred())
 			}
 

--- a/internal/controller/nonadminrestore_controller_test.go
+++ b/internal/controller/nonadminrestore_controller_test.go
@@ -193,7 +193,7 @@ var _ = ginkgo.Describe("Test full reconcile loop of NonAdminRestore Controller"
 			gomega.Expect(createTestNamespaces(ctx, nonAdminRestoreNamespace, oadpNamespace)).To(gomega.Succeed())
 
 			// Create test BSL
-			testBSL := testStorageLocation("test-create-event", oadpNamespace, "aws", "creative-bucket", "unique-prefix")
+			testBSL := testStorageLocation("test-create-event", oadpNamespace, testuuid, "aws", "creative-bucket", "unique-prefix")
 			err := k8sClient.Create(context.Background(), &testBSL)
 			gomega.Expect(err).ToNot(gomega.HaveOccurred())
 			// if scenario expect backup status completed, then create a velero backup with status completed.
@@ -390,13 +390,13 @@ var _ = ginkgo.Describe("Test full reconcile loop of NonAdminRestore Controller"
 		ginkgo.Entry("Should update NonAdminRestore until Velero Restore completes and then delete it", nonAdminRestoreFullReconcileScenario{
 			spec: nacv1alpha1.NonAdminRestoreSpec{
 				RestoreSpec: &velerov1.RestoreSpec{
-					BackupName: "test-uuid",
+					BackupName: testuuid,
 				},
 			},
 			backupStatus: nacv1alpha1.NonAdminBackupStatus{
 				Phase: nacv1alpha1.NonAdminPhaseCreated,
 				VeleroBackup: &nacv1alpha1.VeleroBackup{
-					NACUUID: "test-uuid",
+					NACUUID: testuuid,
 					Status: &velerov1.BackupStatus{
 						Phase:               velerov1.BackupPhaseCompleted,
 						CompletionTimestamp: &metav1.Time{Time: time.Now()},

--- a/internal/controller/nonadminrestore_controller_test.go
+++ b/internal/controller/nonadminrestore_controller_test.go
@@ -290,7 +290,7 @@ var _ = ginkgo.Describe("Test full reconcile loop of NonAdminRestore Controller"
 			gomega.Expect(checkTestNonAdminRestoreStatus(nonAdminRestore, scenario.status)).To(gomega.Succeed())
 
 			veleroRestore := &velerov1.Restore{}
-			if scenario.status.VeleroRestore != nil && len(nonAdminRestore.Status.VeleroRestore.NACUUID) > 0 { // TODO: There is no entry with len(NACUUID) > 0
+			if scenario.status.VeleroRestore != nil && len(nonAdminRestore.Status.VeleroRestore.NACUUID) > 0 { // NACUUID is populated by NAR reconcile
 				ginkgo.By("Checking if NonAdminRestore Spec was not changed")
 				gomega.Expect(reflect.DeepEqual(
 					nonAdminRestore.Spec,

--- a/pkg/velero/storagelocation/paths/paths.go
+++ b/pkg/velero/storagelocation/paths/paths.go
@@ -1,23 +1,21 @@
-// Copyright 2024.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// Copyright 2024.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//	http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+/*
+Copyright 2024.
 
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package paths  helps NAC controllers with getting relevant object store paths of interests
+// generally as defined in https://github.com/vmware-tanzu/velero/blob/0a280e57863c70495a2dfb65787615a68a0e7b03/pkg/persistence/object_store_layout.go
 package paths
 
 import (
@@ -32,18 +30,18 @@ import (
 
 // BasePathForLocation returns base path for a given storage location
 // <protocol>://<bucket>/<prefix>
-func BasePathForLocation(c client.Client, storageLocation *velerov1.BackupStorageLocation) (basepath string, err error) {
+func BasePathForLocation(storageLocation *velerov1.BackupStorageLocation) (basepath string, err error) {
 	var protocol string
 	switch storageLocation.Spec.Provider {
 	case "aws":
 		protocol = "s3://"
 	// TODO: implement azure
-	// azure format would be source-uri, like https://srcaccount.file.core.windows.net/myshare/mydir...
+	// azure format would be source-uri, like https://srcaccount.file.core.windows.net/myshare/mydir... //nolint:dupword // ehh
 	// see: https://learn.microsoft.com/en-us/cli/azure/storage/file/copy?view=azure-cli-latest#az-storage-file-copy-start
 	// TODO: implement gcp
-	// gcp format would be gs://my-bucket, see: https://cloud.google.com/sdk/gcloud/reference/storage/cp
+	//nolint:dupword // gcp format would be gs://my-bucket, see: https://cloud.google.com/sdk/gcloud/reference/storage/cp
 	default:
-		return "", errors.New("unimplemented provider") //nolint:revive // empty return
+		return "", errors.New("unimplemented provider")
 	}
 	return path.Join(protocol, storageLocation.Spec.ObjectStorage.Bucket, storageLocation.Spec.ObjectStorage.Prefix), nil
 }
@@ -55,9 +53,9 @@ func BasePathForBackup(c client.Client, backup *velerov1.Backup) (basepath strin
 	storageLocation := velerov1.BackupStorageLocation{}
 	err = c.Get(context.Background(), client.ObjectKey{Name: storageLocationName, Namespace: backup.Namespace}, &storageLocation)
 	if err != nil {
-		return "", errors.Join(errors.New("unable to get base path for backup"), err) //nolint:revive // empty return
+		return "", errors.Join(errors.New("unable to get base path for backup"), err)
 	}
-	return BasePathForLocation(c, &storageLocation)
+	return BasePathForLocation(&storageLocation)
 }
 
 // BasePathForRestore returns base path for a given restore
@@ -77,7 +75,7 @@ func BasePathForRestore(c client.Client, restore *velerov1.Restore) (basepath st
 func BackupLogs(c client.Client, backup *velerov1.Backup) (string, error) {
 	basepath, err := BasePathForBackup(c, backup)
 	if err != nil {
-		return "", err //nolint:revive // empty return
+		return "", err
 	}
 	return path.Join(basepath, "backups", backup.Name, fmt.Sprintf("%s-logs.gz", backup.Name)), nil
 }
@@ -86,7 +84,7 @@ func BackupLogs(c client.Client, backup *velerov1.Backup) (string, error) {
 func RestoreLogs(c client.Client, restore *velerov1.Restore) (string, error) {
 	basepath, err := BasePathForRestore(c, restore)
 	if err != nil {
-		return "", err //nolint:revive // empty return
+		return "", err
 	}
 	return path.Join(basepath, "restores", restore.Name, fmt.Sprintf("restore-%s-logs.gz", restore.Name)), nil
 }
@@ -96,7 +94,7 @@ func RestoreLogs(c client.Client, restore *velerov1.Restore) (string, error) {
 func BackupResourceList(c client.Client, backup *velerov1.Backup) (string, error) {
 	basepath, err := BasePathForBackup(c, backup)
 	if err != nil {
-		return "", err //nolint:revive // empty return
+		return "", err
 	}
 	return path.Join(basepath, "backups", backup.Name, fmt.Sprintf("%s-resource-list.json.gz", backup.Name)), nil
 }
@@ -105,7 +103,7 @@ func BackupResourceList(c client.Client, backup *velerov1.Backup) (string, error
 func RestoreResourceList(c client.Client, restore *velerov1.Restore) (string, error) {
 	basepath, err := BasePathForRestore(c, restore)
 	if err != nil {
-		return "", err //nolint:revive // empty return
+		return "", err
 	}
 	return path.Join(basepath, "restores", restore.Name, fmt.Sprintf("restore-%s-resource-list.json.gz", restore.Name)), nil
 }

--- a/pkg/velero/storagelocation/paths/paths.go
+++ b/pkg/velero/storagelocation/paths/paths.go
@@ -1,0 +1,111 @@
+// Copyright 2024.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// Copyright 2024.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package paths
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"path"
+
+	velerov1 "github.com/vmware-tanzu/velero/pkg/apis/velero/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// BasePathForLocation returns base path for a given storage location
+// <protocol>://<bucket>/<prefix>
+func BasePathForLocation(c client.Client, storageLocation *velerov1.BackupStorageLocation) (basepath string, err error) {
+	var protocol string
+	switch storageLocation.Spec.Provider {
+	case "aws":
+		protocol = "s3://"
+	// TODO: implement azure
+	// azure format would be source-uri, like https://srcaccount.file.core.windows.net/myshare/mydir...
+	// see: https://learn.microsoft.com/en-us/cli/azure/storage/file/copy?view=azure-cli-latest#az-storage-file-copy-start
+	// TODO: implement gcp
+	// gcp format would be gs://my-bucket, see: https://cloud.google.com/sdk/gcloud/reference/storage/cp
+	default:
+		return "", errors.New("unimplemented provider") //nolint:revive // empty return
+	}
+	return path.Join(protocol, storageLocation.Spec.ObjectStorage.Bucket, storageLocation.Spec.ObjectStorage.Prefix), nil
+}
+
+// BasePathForBackup returns base path for a given backup
+func BasePathForBackup(c client.Client, backup *velerov1.Backup) (basepath string, err error) {
+	// get storage location
+	storageLocationName := backup.Spec.StorageLocation
+	storageLocation := velerov1.BackupStorageLocation{}
+	err = c.Get(context.Background(), client.ObjectKey{Name: storageLocationName, Namespace: backup.Namespace}, &storageLocation)
+	if err != nil {
+		return "", errors.Join(errors.New("unable to get base path for backup"), err) //nolint:revive // empty return
+	}
+	return BasePathForLocation(c, &storageLocation)
+}
+
+// BasePathForRestore returns base path for a given restore
+func BasePathForRestore(c client.Client, restore *velerov1.Restore) (basepath string, err error) {
+	// get backup name
+	backupName := restore.Spec.BackupName
+	backup := velerov1.Backup{}
+	err = c.Get(context.Background(), client.ObjectKey{Name: backupName, Namespace: restore.Namespace}, &backup)
+	if err != nil {
+		return "", errors.Join(errors.New("unable to get base path for restore"), err) //nolint:revive // empty return
+	}
+	return BasePathForBackup(c, &backup)
+}
+
+// BackupLogs returns path to backup logs
+// <basepath>/backups/<backup-name>/<backup-name>-logs.gz
+func BackupLogs(c client.Client, backup *velerov1.Backup) (string, error) {
+	basepath, err := BasePathForBackup(c, backup)
+	if err != nil {
+		return "", err //nolint:revive // empty return
+	}
+	return path.Join(basepath, "backups", backup.Name, fmt.Sprintf("%s-logs.gz", backup.Name)), nil
+}
+
+// RestoreLogs returns path to restore logs
+func RestoreLogs(c client.Client, restore *velerov1.Restore) (string, error) {
+	basepath, err := BasePathForRestore(c, restore)
+	if err != nil {
+		return "", err //nolint:revive // empty return
+	}
+	return path.Join(basepath, "restores", restore.Name, fmt.Sprintf("restore-%s-logs.gz", restore.Name)), nil
+}
+
+// BackupResourceList returns path to backup resource list
+// <basepath>/backups/<backup-name>/<backup-name>-resource-list.json.gz
+func BackupResourceList(c client.Client, backup *velerov1.Backup) (string, error) {
+	basepath, err := BasePathForBackup(c, backup)
+	if err != nil {
+		return "", err //nolint:revive // empty return
+	}
+	return path.Join(basepath, "backups", backup.Name, fmt.Sprintf("%s-resource-list.json.gz", backup.Name)), nil
+}
+
+// RestoreResourceList returns path to restore resource list
+func RestoreResourceList(c client.Client, restore *velerov1.Restore) (string, error) {
+	basepath, err := BasePathForRestore(c, restore)
+	if err != nil {
+		return "", err //nolint:revive // empty return
+	}
+	return path.Join(basepath, "restores", restore.Name, fmt.Sprintf("restore-%s-resource-list.json.gz", restore.Name)), nil
+}


### PR DESCRIPTION
Signed-off-by: Tiger Kaovilai <tkaovila@redhat.com>

## Why the changes were made

This PR adds logs and resourceList to NAB/NAR CR status on their completion status update.

oadp-operator PR: https://github.com/openshift/oadp-operator/pull/1628

Fixes #132 

## How to test the changes made

Create NAB or NAR and wait till completion and check if status contain populated paths of logs and resourceList .gz files.

#### Dev test results
TBC
###
```
make docker-build IMG=$(ghcr_notag):132
docker build --platform=$(dockerplatforms-amdarmibm) --push -t ghcr.io/kaovilai/oadp-non-admin:132 .
```