### PR TITLE
Restrict NonAdminBSL to set default flag

### DIFF
--- a/internal/common/function/function.go
+++ b/internal/common/function/function.go
@@ -171,6 +171,9 @@ func ValidateRestoreSpec(ctx context.Context, clientInstance client.Client, nonA
 func ValidateBslSpec(ctx context.Context, clientInstance client.Client, nonAdminBsl *nacv1alpha1.NonAdminBackupStorageLocation) error {
 	// TODO Introduce validation for NaBSL as described in the
 	// https://github.com/migtools/oadp-non-admin/issues/146
+	if nonAdminBsl.Spec.BackupStorageLocationSpec.Default {
+		return fmt.Errorf("NonAdminBackupStorageLocation can not set spec.bslSpec.default to true")
+	}
 	if nonAdminBsl.Spec.BackupStorageLocationSpec.Credential == nil {
 		return fmt.Errorf("NonAdminBackupStorageLocation spec.bslSpec.credential is not set")
 	} else if nonAdminBsl.Spec.BackupStorageLocationSpec.Credential.Name == constant.EmptyString || nonAdminBsl.Spec.BackupStorageLocationSpec.Credential.Key == constant.EmptyString {

--- a/internal/common/function/function.go
+++ b/internal/common/function/function.go
@@ -172,7 +172,7 @@ func ValidateBslSpec(ctx context.Context, clientInstance client.Client, nonAdmin
 	// TODO Introduce validation for NaBSL as described in the
 	// https://github.com/migtools/oadp-non-admin/issues/146
 	if nonAdminBsl.Spec.BackupStorageLocationSpec.Default {
-		return fmt.Errorf("NonAdminBackupStorageLocation can not set spec.bslSpec.default to true")
+		return fmt.Errorf("NonAdminBackupStorageLocation cannot be used as a default BSL")
 	}
 	if nonAdminBsl.Spec.BackupStorageLocationSpec.Credential == nil {
 		return fmt.Errorf("NonAdminBackupStorageLocation spec.bslSpec.credential is not set")

--- a/internal/common/function/function_test.go
+++ b/internal/common/function/function_test.go
@@ -780,6 +780,17 @@ func TestValidateBslSpec(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "[invalid] spec.bslSpec.default is set to true",
+			nonAdminBsl: &nacv1alpha1.NonAdminBackupStorageLocation{
+				Spec: nacv1alpha1.NonAdminBackupStorageLocationSpec{
+					BackupStorageLocationSpec: &velerov1.BackupStorageLocationSpec{
+						Default: true,
+					},
+				},
+			},
+			errorMessage: "NonAdminBackupStorageLocation can not set spec.bslSpec.default to true",
+		},
 	}
 
 	for _, test := range tests {

--- a/internal/common/function/function_test.go
+++ b/internal/common/function/function_test.go
@@ -789,7 +789,7 @@ func TestValidateBslSpec(t *testing.T) {
 					},
 				},
 			},
-			errorMessage: "NonAdminBackupStorageLocation can not set spec.bslSpec.default to true",
+			errorMessage: "NonAdminBackupStorageLocation cannot be used as a default BSL",
 		},
 	}
 


### PR DESCRIPTION
Partial implementation for the #146

## Why the changes were made

<!-- Explain why this PR is important, what problems it fixes, link related issues -->
To restrict default flag from being used for the NaBSL objects.

## How to test the changes made

<!-- Explain how the changes introduced by this PR can be tested and verified, with commands and pictures -->
Run tests
```shell
$ make simulation-tests
```