### PR TITLE
Remove associated Velero Backups after BSL removal

### DIFF
--- a/docs/design/non_admin_backupstoragelocation.md
+++ b/docs/design/non_admin_backupstoragelocation.md
@@ -28,15 +28,19 @@ flowchart TD
 
     %% Delete Flow
     OPERATION -->|**Delete**| SET_PHASE_DELETING[Set Phase: Deleting]
-    SET_PHASE_DELETING --> CHECK_SECRET_EXISTS{Check if Secret Exists}
+    SET_PHASE_DELETING --> CHECK_SECRET_EXISTS{Check if Secret for the NaBSL Exists}
     CHECK_SECRET_EXISTS -->|Yes| DELETE_SECRET[Delete Secret in OADP Namespace]
-    CHECK_SECRET_EXISTS -->|No| CHECK_BSL_EXISTS{Check if Velero BSL Exists}
+    CHECK_SECRET_EXISTS -->|No| CHECK_BSL_EXISTS{Check if Velero BSL for the NaBSL Exists}
 
     DELETE_SECRET --> CHECK_BSL_EXISTS
     CHECK_BSL_EXISTS -->|Yes| DELETE_BSL[Delete Velero BSL Resource in OADP Namespace]
-    CHECK_BSL_EXISTS -->|No| REMOVE_FINALIZER[Remove Finalizer from NaBSL Resource]
+    CHECK_BSL_EXISTS -->|No| CHECK_BACKUPS_EXISTS{Check if Velero Backups for the NaBSL Exists}
 
-    DELETE_BSL --> REMOVE_FINALIZER
+    DELETE_BSL --> CHECK_BACKUPS_EXISTS
+    CHECK_BACKUPS_EXISTS -->|Yes| DELETE_BACKUPS[Delete Velero Backups in OADP Namespace]
+    CHECK_BACKUPS_EXISTS -->|No| REMOVE_FINALIZER[Remove Finalizer from NaBSL Resource]
+
+    DELETE_BACKUPS --> REMOVE_FINALIZER
 
     %% Endpoints
     INVALID_CONFIG --> END[End Reconciliation]
@@ -61,6 +65,8 @@ flowchart TD
     DELETE_SECRET
     CHECK_BSL_EXISTS
     DELETE_BSL
+    CHECK_BACKUPS_EXISTS
+    DELETE_BACKUPS
     REMOVE_FINALIZER
     end
 
@@ -72,8 +78,8 @@ flowchart TD
 
     %% Apply styles
     class START,END endpoint
-    class OPERATION,VALIDATE_CONFIG,CHECK_SECRET_EXISTS,CHECK_BSL_EXISTS decision
-    class GENERATE_UUID,CREATE_OR_UPDATE_SECRET,CREATE_OR_UPDATE_BSL,DELETE_SECRET,DELETE_BSL,REMOVE_FINALIZER process
+    class OPERATION,VALIDATE_CONFIG,CHECK_SECRET_EXISTS,CHECK_BSL_EXISTS,CHECK_BACKUPS_EXISTS decision
+    class GENERATE_UUID,CREATE_OR_UPDATE_SECRET,CREATE_OR_UPDATE_BSL,DELETE_SECRET,DELETE_BSL,DELETE_BACKUPS,REMOVE_FINALIZER process
     class INVALID_CONFIG,UPDATE_STATUS,VALID_CONFIG,SET_PHASE_DELETING,SET_PHASE_NEW,SET_PHASE_CREATED phase
 ```
 
@@ -118,4 +124,5 @@ flowchart TD
 1. User deletes the Non-Admin BSL resource.
 2. Controller deletes the Secret from the OADP namespace based on the Non-Admin BSL UUID.
 3. Controller deletes the Velero BSL resource from the OADP namespace based on the Non-Admin BSL UUID.
-4. Controller removes the finalizer from the Non-Admin BSL resource.
+4. Controller deletes the Velero Backups for the NaBSL from the OADP namespace based on the Non-Admin BSL UUID.
+5. Controller removes the finalizer from the Non-Admin BSL resource.

--- a/internal/common/constant/constant.go
+++ b/internal/common/constant/constant.go
@@ -67,6 +67,9 @@ const NamespaceString = "Namespace"
 // NameString defines a constant for the Name string
 const NameString = "name"
 
+// BackupString defines a constant for the Backup string
+const BackupString = "backup"
+
 // CurrentPhaseString defines a constant for the Current Phase string
 const CurrentPhaseString = "currentPhase"
 


### PR DESCRIPTION
 - adds label to the Velero Backup object from the origin NaBSL
 - cleans up the Velero Backup objects with the associated label

## Why the changes were made

<!-- Explain why this PR is important, what problems it fixes, link related issues -->
Removal of the Backup objects after NaBSL removal should happen from the non admin BSL reconcile.

If there are any left-overs GC should take action, so the GC controller should be independent of this logic.

Responsibility to clean up Non Admin Backups when the Velero Backups objects are removed is GC.

## How to test the changes made

<!-- Explain how the changes introduced by this PR can be tested and verified, with commands and pictures -->
1. Create NaBSL
2. Associate the Backup with the NaBSL
3. Remove the NaBSL
4. Ensure the Velero Backup is deleted