### PR TITLE
feat(Makefile): add docker cli image load support so it can later be pushed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -93,7 +93,7 @@ run: manifests generate fmt vet ## Run a controller from your host.
 # More info: https://docs.docker.com/develop/develop-images/build_enhancements/
 .PHONY: docker-build
 docker-build: ## Build docker image with the manager.
-	$(CONTAINER_TOOL) build -t ${IMG} .
+	$(CONTAINER_TOOL) build --load -t ${IMG} .
 
 .PHONY: docker-push
 docker-push: ## Push docker image with the manager.


### PR DESCRIPTION
Signed-off-by: Tiger Kaovilai <tkaovila@redhat.com>

## Why the changes were made

docker cli will fail to build image without loading image or pushing image
same as https://github.com/kubernetes-sigs/kubebuilder/issues/4546 being fixed in https://github.com/kubernetes-sigs/kubebuilder/pull/4547

## How to test the changes made

<!-- Explain how the changes introduced by this PR can be tested and verified, with commands and pictures -->
