### PR TITLE
feat(Makefile): add support for pushing docker image after building it

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -95,6 +95,10 @@ run: manifests generate fmt vet ## Run a controller from your host.
 docker-build: ## Build docker image with the manager.
 	$(CONTAINER_TOOL) build -t ${IMG} .
 
+.PHONY: docker-build-push
+docker-build-push: ## Build and push docker image with the manager.
+	$(CONTAINER_TOOL) build --push -t ${IMG} .
+
 .PHONY: docker-push
 docker-push: ## Push docker image with the manager.
 	$(CONTAINER_TOOL) push ${IMG}


### PR DESCRIPTION
Signed-off-by: Tiger Kaovilai <tkaovila@redhat.com>

## Why the changes were made

docker cli can push an image built without loading into system first.

## How to test the changes made

<!-- Explain how the changes introduced by this PR can be tested and verified, with commands and pictures -->
