### PR TITLE
Exclude NAC resources from backup

### DIFF
--- a/api/v1alpha1/nonadmin_types.go
+++ b/api/v1alpha1/nonadmin_types.go
@@ -50,3 +50,9 @@ type QueueInfo struct {
 	// estimatedQueuePosition is the number of operations ahead in the queue (0 if not queued)
 	EstimatedQueuePosition int `json:"estimatedQueuePosition"`
 }
+
+const (
+	NonAdminBackups                = "nonadminbackups"
+	NonAdminRestores               = "nonadminrestores"
+	NonAdminBackupStorageLocations = "nonadminbackupstoragelocations"
+)

--- a/internal/controller/nonadminbackup_controller.go
+++ b/internal/controller/nonadminbackup_controller.go
@@ -641,6 +641,13 @@ func (r *NonAdminBackupReconciler) createVeleroBackupAndSyncWithNonAdminBackup(c
 			backupSpec.StorageLocation = nonAdminBsl.Status.VeleroBackupStorageLocation.Name
 		}
 
+		// Exclude NAC resources (NAB, NAR, NABSL) from Non-Admin backups
+		backupSpec.ExcludedResources = []string{
+			nacv1alpha1.NonAdminBackups,
+			nacv1alpha1.NonAdminRestores,
+			nacv1alpha1.NonAdminBackupStorageLocations,
+		}
+
 		veleroBackup := velerov1.Backup{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:        veleroBackupNACUUID,

--- a/internal/controller/nonadminbackup_controller_test.go
+++ b/internal/controller/nonadminbackup_controller_test.go
@@ -1086,6 +1086,11 @@ var _ = ginkgo.Describe("Test full reconcile loop of NonAdminBackup Controller",
 					ginkgo.By("Validating Velero Backup Spec")
 					expectedSpec := scenario.enforcedBackupSpec.DeepCopy()
 					expectedSpec.IncludedNamespaces = []string{nonAdminObjectNamespace}
+					expectedSpec.ExcludedResources = []string{
+						nacv1alpha1.NonAdminBackups,
+						nacv1alpha1.NonAdminRestores,
+						nacv1alpha1.NonAdminBackupStorageLocations,
+					}
 					gomega.Expect(reflect.DeepEqual(veleroBackup.Spec, *expectedSpec)).To(gomega.BeTrue())
 				}
 


### PR DESCRIPTION
## Why the changes were made

<!-- Explain why this PR is important, what problems it fixes, link related issues -->

Fixes https://github.com/migtools/oadp-non-admin/issues/189

## How to test the changes made

<!-- Explain how the changes introduced by this PR can be tested and verified, with commands and pictures -->

- Try creating a NAB backup
- Check the backup spec and resource List as well once the backup completes
- At both the places, NAC resources must be absent
