### PR TITLE
Add validation error on NAB for restricted spec values

### DIFF
--- a/internal/common/constant/constant.go
+++ b/internal/common/constant/constant.go
@@ -82,3 +82,6 @@ const CommaString = ","
 // MaximumNacObjectNameLength represents Generated Non Admin Object Name and
 // must be below 63 characters, because it's used within object Label Value
 const MaximumNacObjectNameLength = validation.DNS1123LabelMaxLength
+
+// NABRestrictedErr holds an error message template for a non-admin backup operation that is restricted.
+const NABRestrictedErr = "NonAdminBackup %s is restricted"

--- a/internal/common/function/function.go
+++ b/internal/common/function/function.go
@@ -100,10 +100,12 @@ func ValidateBackupSpec(ctx context.Context, clientInstance client.Client, oadpN
 		return fmt.Errorf("NonAdminBackup spec.backupSpec.excludedNamespaces is restricted")
 	}
 
-	if enforcedBackupSpec.IncludedNamespaces != nil {
-		if !containsOnlyNamespace(enforcedBackupSpec.IncludedNamespaces, nonAdminBackup.Namespace) {
-			return fmt.Errorf("NonAdminBackup spec.backupSpec.includedNamespaces enforced value by admin user violates NAC usage")
-		}
+	if nonAdminBackup.Spec.BackupSpec.IncludeClusterResources != nil && *nonAdminBackup.Spec.BackupSpec.IncludeClusterResources {
+		return fmt.Errorf("NonAdminBackup spec.backupSpec.includeClusterResources can not be set or must be set to false")
+	}
+
+	if len(nonAdminBackup.Spec.BackupSpec.IncludedClusterScopedResources) > 0 {
+		return fmt.Errorf("NonAdminBackup spec.backupSpec.includedClusterScopedResources is restricted, only an empty list is allowed")
 	}
 
 	if nonAdminBackup.Spec.BackupSpec.StorageLocation != constant.EmptyString {

--- a/internal/common/function/function.go
+++ b/internal/common/function/function.go
@@ -92,20 +92,20 @@ func containsOnlyNamespace(namespaces []string, namespace string) bool {
 func ValidateBackupSpec(ctx context.Context, clientInstance client.Client, oadpNamespace string, nonAdminBackup *nacv1alpha1.NonAdminBackup, enforcedBackupSpec *velerov1.BackupSpec) error {
 	if nonAdminBackup.Spec.BackupSpec.IncludedNamespaces != nil {
 		if !containsOnlyNamespace(nonAdminBackup.Spec.BackupSpec.IncludedNamespaces, nonAdminBackup.Namespace) {
-			return fmt.Errorf("NonAdminBackup spec.backupSpec.includedNamespaces can not contain namespaces other than: %s", nonAdminBackup.Namespace)
+			return fmt.Errorf(constant.NABRestrictedErr+", can not contain namespaces other than: %s", "spec.backupSpec.includedNamespaces", nonAdminBackup.Namespace)
 		}
 	}
 
 	if nonAdminBackup.Spec.BackupSpec.ExcludedNamespaces != nil {
-		return fmt.Errorf("NonAdminBackup spec.backupSpec.excludedNamespaces is restricted")
+		return fmt.Errorf(constant.NABRestrictedErr, "spec.backupSpec.excludedNamespaces")
 	}
 
 	if nonAdminBackup.Spec.BackupSpec.IncludeClusterResources != nil && *nonAdminBackup.Spec.BackupSpec.IncludeClusterResources {
-		return fmt.Errorf("NonAdminBackup spec.backupSpec.includeClusterResources can not be set or must be set to false")
+		return fmt.Errorf(constant.NABRestrictedErr+", can only be set to false", "spec.backupSpec.includeClusterResources")
 	}
 
 	if len(nonAdminBackup.Spec.BackupSpec.IncludedClusterScopedResources) > 0 {
-		return fmt.Errorf("NonAdminBackup spec.backupSpec.includedClusterScopedResources is restricted, only an empty list is allowed")
+		return fmt.Errorf(constant.NABRestrictedErr+", must remain empty", "spec.backupSpec.includedScopedResources")
 	}
 
 	if nonAdminBackup.Spec.BackupSpec.StorageLocation != constant.EmptyString {

--- a/internal/common/function/function.go
+++ b/internal/common/function/function.go
@@ -95,6 +95,11 @@ func ValidateBackupSpec(ctx context.Context, clientInstance client.Client, oadpN
 			return fmt.Errorf("NonAdminBackup spec.backupSpec.includedNamespaces can not contain namespaces other than: %s", nonAdminBackup.Namespace)
 		}
 	}
+
+	if nonAdminBackup.Spec.BackupSpec.ExcludedNamespaces != nil {
+		return fmt.Errorf("NonAdminBackup spec.backupSpec.excludedNamespaces is restricted")
+	}
+
 	if enforcedBackupSpec.IncludedNamespaces != nil {
 		if !containsOnlyNamespace(enforcedBackupSpec.IncludedNamespaces, nonAdminBackup.Namespace) {
 			return fmt.Errorf("NonAdminBackup spec.backupSpec.includedNamespaces enforced value by admin user violates NAC usage")

--- a/internal/common/function/function_test.go
+++ b/internal/common/function/function_test.go
@@ -131,7 +131,7 @@ func TestValidateBackupSpec(t *testing.T) {
 		{
 			name: "non admin users specify includedClusterScopedResources",
 			spec: &velerov1.BackupSpec{
-				IncludedClusterScopedResources: []string{"foo", "bar"},
+				IncludedClusterScopedResources: []string{"foo-something-coz-lint", "bar"},
 			},
 			errMessage: "NonAdminBackup spec.backupSpec.includedClusterScopedResources is restricted, only an empty list is allowed",
 		},

--- a/internal/common/function/function_test.go
+++ b/internal/common/function/function_test.go
@@ -116,6 +116,13 @@ func TestValidateBackupSpec(t *testing.T) {
 			},
 		},
 		{
+			name: "invalid spec, excluded ns specified in nab backu spec",
+			spec: &velerov1.BackupSpec{
+				ExcludedNamespaces: []string{testNonAdminBackupNamespace},
+			},
+			errMessage: "NonAdminBackup spec.backupSpec.excludedNamespaces is restricted",
+		},
+		{
 			name: "non admin backupstoragelocation not found in the NonAdminBackup namespace",
 			spec: &velerov1.BackupSpec{
 				StorageLocation: "user-defined-backup-storage-location",

--- a/internal/common/function/function_test.go
+++ b/internal/common/function/function_test.go
@@ -19,6 +19,7 @@ package function
 import (
 	"context"
 	"errors"
+	"fmt"
 	"reflect"
 	"strings"
 	"testing"
@@ -106,7 +107,7 @@ func TestValidateBackupSpec(t *testing.T) {
 			spec: &velerov1.BackupSpec{
 				IncludedNamespaces: []string{"namespace1", "namespace2", "namespace3"},
 			},
-			errMessage: "NonAdminBackup spec.backupSpec.includedNamespaces can not contain namespaces other than: non-admin-backup-namespace",
+			errMessage: fmt.Sprintf(constant.NABRestrictedErr+", can not contain namespaces other than: %s", "spec.backupSpec.includedNamespaces", "non-admin-backup-namespace"),
 		},
 		{
 			name: "valid spec",
@@ -119,21 +120,21 @@ func TestValidateBackupSpec(t *testing.T) {
 			spec: &velerov1.BackupSpec{
 				ExcludedNamespaces: []string{testNonAdminBackupNamespace},
 			},
-			errMessage: "NonAdminBackup spec.backupSpec.excludedNamespaces is restricted",
+			errMessage: fmt.Sprintf(constant.NABRestrictedErr, "spec.backupSpec.excludedNamespaces"),
 		},
 		{
 			name: "non admin users specify includeClusterResources as true",
 			spec: &velerov1.BackupSpec{
 				IncludeClusterResources: ptr.To(true),
 			},
-			errMessage: "NonAdminBackup spec.backupSpec.includeClusterResources can not be set or must be set to false",
+			errMessage: fmt.Sprintf(constant.NABRestrictedErr+", can only be set to false", "spec.backupSpec.includeClusterResources"),
 		},
 		{
 			name: "non admin users specify includedClusterScopedResources",
 			spec: &velerov1.BackupSpec{
 				IncludedClusterScopedResources: []string{"foo-something-coz-lint", "bar"},
 			},
-			errMessage: "NonAdminBackup spec.backupSpec.includedClusterScopedResources is restricted, only an empty list is allowed",
+			errMessage: fmt.Sprintf(constant.NABRestrictedErr+", must remain empty", "spec.backupSpec.includedScopedResources"),
 		},
 		{
 			name: "non admin backupstoragelocation not found in the NonAdminBackup namespace",

--- a/internal/common/function/function_test.go
+++ b/internal/common/function/function_test.go
@@ -116,7 +116,7 @@ func TestValidateBackupSpec(t *testing.T) {
 			},
 		},
 		{
-			name: "invalid spec, excluded ns specified in nab backu spec",
+			name: "invalid spec, excluded ns specified in nab backup spec",
 			spec: &velerov1.BackupSpec{
 				ExcludedNamespaces: []string{testNonAdminBackupNamespace},
 			},
@@ -183,11 +183,6 @@ func TestValidateBackupSpecEnforcedFields(t *testing.T) {
 			name:          "IncludedNamespaces",
 			enforcedValue: []string{"self-service-namespace"},
 			overrideValue: []string{"openshift-adp"},
-		},
-		{
-			name:          "ExcludedNamespaces",
-			enforcedValue: []string{"openshift-adp"},
-			overrideValue: []string{"cherry"},
 		},
 		{
 			name:          "IncludedResources",

--- a/internal/common/function/function_test.go
+++ b/internal/common/function/function_test.go
@@ -202,7 +202,7 @@ func TestValidateBackupSpecEnforcedFields(t *testing.T) {
 		},
 		{
 			name:                "ExcludedNamespaces",
-			enforcedValue:       []string{"nonadminbackups.nac.oadp.openshift.io"},
+			enforcedValue:       []string{"sample-ns"},
 			overrideValue:       []string{},
 			expectErrorEnforced: true,
 		},
@@ -590,7 +590,7 @@ func TestValidateRestoreSpecEnforcedFields(t *testing.T) {
 		},
 		{
 			name:          "ExcludedResources",
-			enforcedValue: []string{"nonadminbackups.nac.oadp.openshift.io"},
+			enforcedValue: []string{"foobar.io"},
 			overrideValue: []string{},
 		},
 		{

--- a/internal/controller/nonadminbackup_controller_test.go
+++ b/internal/controller/nonadminbackup_controller_test.go
@@ -496,11 +496,11 @@ var _ = ginkgo.Describe("Test single reconciles of NonAdminBackup Reconcile func
 						Type:    string(nacv1alpha1.NonAdminConditionAccepted),
 						Status:  metav1.ConditionFalse,
 						Reason:  "InvalidBackupSpec",
-						Message: "NonAdminBackup spec.backupSpec.includedNamespaces can not contain namespaces other than: ",
+						Message: fmt.Sprintf(constant.NABRestrictedErr+", can not contain namespaces other than: %s", "spec.backupSpec.includedNamespaces", ""),
 					},
 				},
 			},
-			resultError: reconcile.TerminalError(fmt.Errorf("NonAdminBackup spec.backupSpec.includedNamespaces can not contain namespaces other than: ")),
+			resultError: reconcile.TerminalError(fmt.Errorf(constant.NABRestrictedErr+", can not contain namespaces other than: %s", "spec.backupSpec.includedNamespaces", "")),
 		}),
 		ginkgo.Entry("When triggered by NonAdminBackup Create event with not existing NonAdminBackupStorageLocation, should update NonAdminBackup phase to BackingOff and exit with terminal error", nonAdminBackupSingleReconcileScenario{
 			createNonAdminBackupStorageLocation: false,
@@ -966,11 +966,11 @@ var _ = ginkgo.Describe("Test single reconciles of NonAdminBackup Reconcile func
 						Type:    string(nacv1alpha1.NonAdminConditionAccepted),
 						Status:  metav1.ConditionFalse,
 						Reason:  "InvalidBackupSpec",
-						Message: "NonAdminBackup spec.backupSpec.includedNamespaces can not contain namespaces other than:",
+						Message: fmt.Sprintf(constant.NABRestrictedErr+", can not contain namespaces other than: %s", "spec.backupSpec.includedNamespaces", ""),
 					},
 				},
 			},
-			resultError: reconcile.TerminalError(fmt.Errorf("NonAdminBackup spec.backupSpec.includedNamespaces can not contain namespaces other than: ")),
+			resultError: reconcile.TerminalError(fmt.Errorf(constant.NABRestrictedErr+", can not contain namespaces other than: %s", "spec.backupSpec.includedNamespaces", "")),
 		}))
 })
 


### PR DESCRIPTION
## Why the changes were made

<!-- Explain why this PR is important, what problems it fixes, link related issues -->
Fixes https://github.com/migtools/oadp-non-admin/issues/200
Fixes https://github.com/migtools/oadp-non-admin/issues/201

Related to https://github.com/openshift/oadp-operator/pull/1632
## How to test the changes made

<!-- Explain how the changes introduced by this PR can be tested and verified, with commands and pictures -->
- Try specifying excludedNamespaces, IncludeClusterResources as true, and non-empty IncludedClusterScopedResources  on NAB backup spec
- NAB should error out 
