### PR TITLE
fix: NonAdmin objects associated objects deletion info

### DIFF
--- a/api/v1alpha1/nonadminbackup_types.go
+++ b/api/v1alpha1/nonadminbackup_types.go
@@ -26,8 +26,8 @@ type NonAdminBackupSpec struct {
 	// BackupSpec defines the specification for a Velero backup.
 	BackupSpec *velerov1.BackupSpec `json:"backupSpec"`
 
-	// DeleteBackup removes the NonAdminBackup and its associated VeleroBackup from the cluster,
-	// as well as the corresponding object storage
+	// DeleteBackup removes the NonAdminBackup and its associated NonAdminRestores and VeleroBackup from the cluster,
+	// as well as the corresponding data in object storage
 	// +optional
 	DeleteBackup bool `json:"deleteBackup,omitempty"`
 }

--- a/config/crd/bases/oadp.openshift.io_nonadminbackups.yaml
+++ b/config/crd/bases/oadp.openshift.io_nonadminbackups.yaml
@@ -523,8 +523,8 @@ spec:
                 type: object
               deleteBackup:
                 description: |-
-                  DeleteBackup removes the NonAdminBackup and its associated VeleroBackup from the cluster,
-                  as well as the corresponding object storage
+                  DeleteBackup removes the NonAdminBackup and its associated NonAdminRestores and VeleroBackup from the cluster,
+                  as well as the corresponding data in object storage
                 type: boolean
             required:
             - backupSpec

--- a/internal/handler/velerobackup_handler.go
+++ b/internal/handler/velerobackup_handler.go
@@ -53,8 +53,18 @@ func (VeleroBackupHandler) Update(ctx context.Context, evt event.UpdateEvent, q 
 }
 
 // Delete event handler
-func (VeleroBackupHandler) Delete(_ context.Context, _ event.DeleteEvent, _ workqueue.RateLimitingInterface) {
-	// Delete event handler for the Backup object
+func (VeleroBackupHandler) Delete(ctx context.Context, evt event.DeleteEvent, q workqueue.RateLimitingInterface) {
+	logger := function.GetLogger(ctx, evt.Object, "VeleroBackupHandler")
+
+	annotations := evt.Object.GetAnnotations()
+	nabOriginNamespace := annotations[constant.NabOriginNamespaceAnnotation]
+	nabOriginName := annotations[constant.NabOriginNameAnnotation]
+
+	q.Add(reconcile.Request{NamespacedName: types.NamespacedName{
+		Name:      nabOriginName,
+		Namespace: nabOriginNamespace,
+	}})
+	logger.V(1).Info("Handled Delete event")
 }
 
 // Generic event handler

--- a/internal/predicate/compositebackup_predicate.go
+++ b/internal/predicate/compositebackup_predicate.go
@@ -61,6 +61,8 @@ func (p CompositeBackupPredicate) Delete(evt event.DeleteEvent) bool {
 	switch evt.Object.(type) {
 	case *nacv1alpha1.NonAdminBackup:
 		return p.NonAdminBackupPredicate.Delete(p.Context, evt)
+	case *velerov1.Backup:
+		return p.VeleroBackupPredicate.Delete(p.Context, evt)
 	default:
 		return false
 	}

--- a/internal/predicate/velerobackup_predicate.go
+++ b/internal/predicate/velerobackup_predicate.go
@@ -45,3 +45,20 @@ func (p VeleroBackupPredicate) Update(ctx context.Context, evt event.UpdateEvent
 	logger.V(1).Info("Rejected Backup Update event")
 	return false
 }
+
+// Delete event filter only accepts Velero Backup delete events from OADP namespace
+// and from Velero Backups that have required metadata
+func (p VeleroBackupPredicate) Delete(ctx context.Context, evt event.DeleteEvent) bool {
+	logger := function.GetLogger(ctx, evt.Object, "VeleroBackupPredicate")
+
+	namespace := evt.Object.GetNamespace()
+	if namespace == p.OADPNamespace {
+		if function.CheckVeleroBackupMetadata(evt.Object) {
+			logger.V(1).Info("Accepted Backup Delete event")
+			return true
+		}
+	}
+
+	logger.V(1).Info("Rejected Backup Delete event")
+	return false
+}

--- a/internal/predicate/velerorestore_predicate.go
+++ b/internal/predicate/velerorestore_predicate.go
@@ -37,12 +37,12 @@ func (p VeleroRestorePredicate) Update(ctx context.Context, evt event.UpdateEven
 	namespace := evt.ObjectNew.GetNamespace()
 	if namespace == p.OADPNamespace {
 		if function.CheckVeleroRestoreMetadata(evt.ObjectNew) {
-			logger.V(1).Info("Accepted Update event")
+			logger.V(1).Info("Accepted Restore Update event")
 			return true
 		}
 	}
 
-	logger.V(1).Info("Rejected Update event")
+	logger.V(1).Info("Rejected Restore Update event")
 	return false
 }
 
@@ -54,11 +54,11 @@ func (p VeleroRestorePredicate) Delete(ctx context.Context, evt event.DeleteEven
 	namespace := evt.Object.GetNamespace()
 	if namespace == p.OADPNamespace {
 		if function.CheckVeleroRestoreMetadata(evt.Object) {
-			logger.V(1).Info("Accepted Delete event")
+			logger.V(1).Info("Accepted Restore Delete event")
 			return true
 		}
 	}
 
-	logger.V(1).Info("Rejected Delete event")
+	logger.V(1).Info("Rejected Restore Delete event")
 	return false
 }


### PR DESCRIPTION
## Why the changes were made

Fix https://github.com/migtools/oadp-non-admin/issues/178

Fix https://github.com/migtools/oadp-non-admin/issues/195

Also add checks to avoid non admin users to maliciously creating NABs that violates NAC rules or using backups from other non admin users.

~Blocked by https://github.com/openshift/oadp-operator/pull/1640~

## How to test the changes made

Follow [install-from-source](https://github.com/migtools/oadp-non-admin/blob/master/docs/CONTRIBUTING.md#install-from-source) testing documentation, pointing this branch and my OADP fork branch [`fix/nac-associated-objects-deletion`](https://github.com/mateusoliveira43/oadp-operator/tree/fix/nac-associated-objects-deletion)

Create NAB, create NAR and then delete associated velero restore. It should be clear in NAR status that its associated velero restore was deleted and not run another restore.

Create NAB, create NAR and then delete NAB using NAB `spec.deleteBackup`. NAR and associated velero restore should be deleted.

Create NAB and then delete associated velero backup. It should be clear in NAB status that its associated velero backup was deleted and not run another backup.
