### PR TITLE
fix: restrict VSL spec in NAB

### DIFF
--- a/internal/common/function/function.go
+++ b/internal/common/function/function.go
@@ -135,6 +135,10 @@ func ValidateBackupSpec(ctx context.Context, clientInstance client.Client, oadpN
 		}
 	}
 
+	if nonAdminBackup.Spec.BackupSpec.VolumeSnapshotLocations != nil {
+		return fmt.Errorf(constant.NABRestrictedErr, "spec.backupSpec.volumeSnapshotLocations")
+	}
+
 	enforcedSpec := reflect.ValueOf(enforcedBackupSpec).Elem()
 	for index := range enforcedSpec.NumField() {
 		enforcedField := enforcedSpec.Field(index)

--- a/internal/common/function/function_test.go
+++ b/internal/common/function/function_test.go
@@ -311,9 +311,10 @@ func TestValidateBackupSpecEnforcedFields(t *testing.T) {
 			overrideValue: "lemon",
 		},
 		{
-			name:          "VolumeSnapshotLocations",
-			enforcedValue: []string{awsProvider},
-			overrideValue: []string{gcpProvider},
+			name:                "VolumeSnapshotLocations",
+			enforcedValue:       []string{awsProvider},
+			overrideValue:       []string{gcpProvider},
+			expectErrorEnforced: true,
 		},
 		{
 			name:          "DefaultVolumesToRestic",
@@ -439,24 +440,25 @@ func TestValidateBackupSpecEnforcedFields(t *testing.T) {
 			if err == nil {
 				t.Errorf("setting backup spec field '%v' with value overriding enforcement test failed: %v", test.name, err)
 			}
-			t.Run("Ensure all backup spec fields were tested", func(t *testing.T) {
-				backupSpecFields := []string{}
-				for _, test := range tests {
-					backupSpecFields = append(backupSpecFields, test.name)
-				}
-				backupSpec := reflect.ValueOf(&velerov1.BackupSpec{}).Elem()
-
-				for index := range backupSpec.NumField() {
-					if !slices.Contains(backupSpecFields, backupSpec.Type().Field(index).Name) {
-						t.Errorf("backup spec field '%v' is not tested", backupSpec.Type().Field(index).Name)
-					}
-				}
-				if backupSpec.NumField() != len(tests) {
-					t.Errorf("list of tests have different number of elements")
-				}
-			})
 		})
 	}
+
+	t.Run("Ensure all backup spec fields were tested", func(t *testing.T) {
+		backupSpecFields := []string{}
+		for _, test := range tests {
+			backupSpecFields = append(backupSpecFields, test.name)
+		}
+		backupSpec := reflect.ValueOf(&velerov1.BackupSpec{}).Elem()
+
+		for index := range backupSpec.NumField() {
+			if !slices.Contains(backupSpecFields, backupSpec.Type().Field(index).Name) {
+				t.Errorf("backup spec field '%v' is not tested", backupSpec.Type().Field(index).Name)
+			}
+		}
+		if backupSpec.NumField() != len(tests) {
+			t.Errorf("list of tests have different number of elements")
+		}
+	})
 }
 
 func TestValidateRestoreSpec(t *testing.T) {


### PR DESCRIPTION
## Why the changes were made

Fix https://github.com/migtools/oadp-non-admin/issues/202

## How to test the changes made

Check that a NAB can not have volumeSnapshotLocations spec set.
