### PR TITLE
LogLevel configuration via dpa env.

### DIFF
--- a/cmd/main_test.go
+++ b/cmd/main_test.go
@@ -1,0 +1,40 @@
+/*
+Copyright 2024.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Entrypoint of the project
+package main
+
+import (
+	"testing"
+
+	_ "github.com/onsi/ginkgo/v2" // To fix: flag provided but not defined: -ginkgo.vv
+	"github.com/sirupsen/logrus"
+)
+
+func Test_translateLogrusToZapLevel(t *testing.T) {
+	for _, level := range logrus.AllLevels {
+		t.Run(level.String(), func(t *testing.T) {
+			// all levels from logrus are expected to be valid
+			zapLevel, invalid := translateLogrusToZapLevel(level)
+			if invalid {
+				t.Error(level.String() + " from logrus did not convert")
+			}
+			if zapLevel.String() == "" {
+				t.Error("empty zap level unexpected")
+			}
+		})
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -10,8 +10,10 @@ require (
 	github.com/onsi/ginkgo/v2 v2.19.0
 	github.com/onsi/gomega v1.33.1
 	github.com/openshift/oadp-operator v1.0.2-0.20250225171529-2e93d8609b8f
+	github.com/sirupsen/logrus v1.9.3
 	github.com/stretchr/testify v1.9.0
 	github.com/vmware-tanzu/velero v1.14.0
+	go.uber.org/zap v1.27.0
 	golang.org/x/sync v0.11.0
 	k8s.io/api v0.30.5
 	k8s.io/apimachinery v0.30.5
@@ -77,11 +79,9 @@ require (
 	github.com/prometheus/client_model v0.6.1 // indirect
 	github.com/prometheus/common v0.60.1 // indirect
 	github.com/prometheus/procfs v0.15.1 // indirect
-	github.com/sirupsen/logrus v1.9.3 // indirect
 	github.com/spf13/cobra v1.7.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
-	go.uber.org/zap v1.27.0 // indirect
 	golang.org/x/exp v0.0.0-20230522175609-2e198f4a06a1 // indirect
 	golang.org/x/net v0.33.0 // indirect
 	golang.org/x/oauth2 v0.24.0 // indirect

--- a/internal/common/constant/constant.go
+++ b/internal/common/constant/constant.go
@@ -51,6 +51,15 @@ const (
 // Common environment variables for the Non Admin Controller
 const (
 	NamespaceEnvVar = "WATCH_NAMESPACE"
+	// Numeric Log Level corresponding to logrus levels (matching velero).
+	// 0 = panic
+	// 1 = Fatal
+	// 2 = Error
+	// 3 = Warn
+	// 4 = Info
+	// 5 = Debug
+	// 6 = Trace
+	LogLevelEnvVar = "LOG_LEVEL"
 )
 
 // EmptyString defines a constant for the empty string
@@ -89,3 +98,9 @@ const NABRestrictedErr = "NonAdminBackup %s is restricted"
 
 // NARRestrictedErr holds an error message template for a non-admin restore operation that is restricted.
 const NARRestrictedErr = "NonAdminRestore %s is restricted"
+
+// Magic numbers
+const (
+	Base10 = 10
+	Bits32 = 32
+)


### PR DESCRIPTION
Signed-off-by: Tiger Kaovilai <tkaovila@redhat.com>

## Why the changes were made
Fixes #51 
<!-- Explain why this PR is important, what problems it fixes, link related issues -->
Pairs with https://github.com/openshift/oadp-operator/pull/1635

To enable log level configuration

## How to test the changes made

<!-- Explain how the changes introduced by this PR can be tested and verified, with commands and pictures -->
From https://github.com/openshift/oadp-operator/pull/1635
```
make deploy-olm
```
operator, and override NAC image to `ghcr.io/kaovilai/oadp-non-admin:loglevelConfiguration`

### Small test
```
❯ docker run --env LOG_LEVEL=1 --env WATCH_NAMESPACE=oadp-operator --rm -it ghcr.io/kaovilai/oadp-non-admin:loglevelConfiguration
2025-02-25T17:32:56Z	INFO	setup	LogLevel: fatal
```
and observe
```
❯ docker run --env LOG_LEVEL=-1 --env WATCH_NAMESPACE=oadp-operator --rm -it ghcr.io/kaovilai/oadp-non-admin:loglevelConfiguration
2025-02-25T17:34:39Z	INFO	setup	LogLevelEnv: -1 is invalid, using default level: info
2025-02-25T17:34:39Z	INFO	setup	LogLevel: info
```