### PR TITLE
Add reconcile of the NaBSL upon Secret creation in a given namespace

### DIFF
--- a/internal/controller/nonadminbackupstoragelocation_controller.go
+++ b/internal/controller/nonadminbackupstoragelocation_controller.go
@@ -160,9 +160,13 @@ func (r *NonAdminBackupStorageLocationReconciler) SetupWithManager(mgr ctrl.Mana
 				VeleroBackupStorageLocationPredicate: predicate.VeleroBackupStorageLocationPredicate{
 					OADPNamespace: r.OADPNamespace,
 				},
+				NonAdminBslSecretPredicate: predicate.NonAdminBslSecretPredicate{},
 			}).
 		Watches(&velerov1.BackupStorageLocation{}, &handler.VeleroBackupStorageLocationHandler{}).
 		Watches(&nacv1alpha1.NonAdminBackupStorageLocationRequest{}, &handler.NonAdminBackupStorageLocationRequestHandler{}).
+		Watches(&corev1.Secret{}, &handler.NonAdminBslSecretHandler{
+			Client: r.Client,
+		}).
 		Complete(r)
 }
 

--- a/internal/handler/nonadminbsl_secret_handler.go
+++ b/internal/handler/nonadminbsl_secret_handler.go
@@ -1,0 +1,80 @@
+/*
+Copyright 2024.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package handler contains all event handlers of the project
+package handler
+
+import (
+	"context"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/util/workqueue"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	nacv1alpha1 "github.com/migtools/oadp-non-admin/api/v1alpha1"
+	"github.com/migtools/oadp-non-admin/internal/common/function"
+)
+
+// NonAdminBslSecretHandler contains event handlers for NonAdminBackupStorageLocation objects
+type NonAdminBslSecretHandler struct {
+	Client client.Client
+}
+
+// Create event handler
+func (h NonAdminBslSecretHandler) Create(ctx context.Context, evt event.CreateEvent, q workqueue.TypedRateLimitingInterface[reconcile.Request]) {
+	// Create event handler for the Secret object
+	logger := function.GetLogger(ctx, evt.Object, "NonAdminBslSecretHandler")
+
+	secret, ok := evt.Object.(*corev1.Secret)
+	if !ok {
+		logger.Error(nil, "Failed to cast event object to Secret")
+		return
+	}
+
+	var nabslList nacv1alpha1.NonAdminBackupStorageLocationList
+	if err := h.Client.List(ctx, &nabslList, client.InNamespace(secret.Namespace)); err != nil {
+		logger.Error(err, "Failed to list NonAdminBackupStorageLocation objects")
+		return
+	}
+
+	for _, nabsl := range nabslList.Items {
+		if nabsl.Spec.BackupStorageLocationSpec.Credential.Name == secret.Name {
+			logger.V(1).Info("Matching NaBSL found", "NaBSL", nabsl.Name, "Secret", secret.Name)
+			q.Add(reconcile.Request{NamespacedName: types.NamespacedName{
+				Name:      nabsl.Name,
+				Namespace: nabsl.Namespace,
+			}})
+		}
+	}
+}
+
+// Update event handler
+func (NonAdminBslSecretHandler) Update(_ context.Context, _ event.UpdateEvent, _ workqueue.TypedRateLimitingInterface[reconcile.Request]) {
+	// Update event handler for the Secret object
+}
+
+// Delete event handler
+func (NonAdminBslSecretHandler) Delete(_ context.Context, _ event.DeleteEvent, _ workqueue.TypedRateLimitingInterface[reconcile.Request]) {
+	// Delete event handler for the Secret object
+}
+
+// Generic event handler
+func (NonAdminBslSecretHandler) Generic(_ context.Context, _ event.GenericEvent, _ workqueue.TypedRateLimitingInterface[reconcile.Request]) {
+	// Generic event handler for the Secret object
+}

--- a/internal/predicate/composite_nabsl_predicate.go
+++ b/internal/predicate/composite_nabsl_predicate.go
@@ -21,6 +21,7 @@ import (
 	"context"
 
 	velerov1 "github.com/vmware-tanzu/velero/pkg/apis/velero/v1"
+	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 
@@ -30,6 +31,7 @@ import (
 // CompositeNaBSLPredicate is a combination of NonAdminBackupStorageLocation and Velero BackupStorageLocation event filters
 type CompositeNaBSLPredicate struct {
 	Context                                       context.Context
+	NonAdminBslSecretPredicate                    NonAdminBslSecretPredicate
 	NonAdminBackupStorageLocationPredicate        NonAdminBackupStorageLocationPredicate
 	NonAdminBackupStorageLocationRequestPredicate NonAdminBackupStorageLocationRequestPredicate
 	VeleroBackupStorageLocationPredicate          VeleroBackupStorageLocationPredicate
@@ -40,6 +42,8 @@ func (p CompositeNaBSLPredicate) Create(evt event.CreateEvent) bool {
 	switch evt.Object.(type) {
 	case *nacv1alpha1.NonAdminBackupStorageLocation:
 		return p.NonAdminBackupStorageLocationPredicate.Create(p.Context, evt)
+	case *corev1.Secret:
+		return p.NonAdminBslSecretPredicate.Create(p.Context, evt)
 	default:
 		return false
 	}

--- a/internal/predicate/nonadminbsl_secret_predicate.go
+++ b/internal/predicate/nonadminbsl_secret_predicate.go
@@ -1,0 +1,48 @@
+/*
+Copyright 2024.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package predicate
+
+import (
+	"context"
+
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+
+	"github.com/migtools/oadp-non-admin/internal/common/function"
+)
+
+// NonAdminBslSecretPredicate contains event filters for Velero BackupStorageLocation objects
+type NonAdminBslSecretPredicate struct{}
+
+// Create event filter only accepts NonAdminBackupStorageLocation create events
+func (NonAdminBslSecretPredicate) Create(ctx context.Context, evt event.CreateEvent) bool {
+	logger := function.GetLogger(ctx, evt.Object, "NonAdminBslSecretPredicate")
+
+	secret, ok := evt.Object.(*corev1.Secret)
+	if !ok {
+		logger.Error(nil, "Failed to cast event object to Secret")
+		return false
+	}
+
+	if secret.Type == corev1.SecretTypeOpaque {
+		logger.V(1).Info("Accepted Create event")
+		return true
+	}
+
+	logger.V(1).Info("Rejected Create event")
+	return false
+}


### PR DESCRIPTION
Add reconcile of the NaBSL upon Secret creation in a given namespace
    
Fixes #212 which reconciles the relevant NaBSL object when the new  Secret is discovered in the user namespace.

Only create events are important, because we do not allow NaBSL updates.

In a handler we compare which NaBSL from the same namespace as secret had the the same credential name as the secret itself and we reconcile on that object. 

## Why the changes were made

To fix #212 

## How to test the changes made

1. Create NaBSL without secret
2. Create secret afterwords in other namespace then the NaBSL (nothing happens)
3. Create secret but with different name in the same namespace as NaBSL (nothing happens) 
4. Create secret that matches the NaBSL credential name (reconcile is fine)

Perform the same steps with enforced name as well perform the same with no credential specified to ensure no corner cases are causing NAC to misbehave.