### PR TITLE
CRD updates for the oc CLI fields for the NAR, NAB and NABSL objects

### DIFF
--- a/api/v1alpha1/nonadminbackup_types.go
+++ b/api/v1alpha1/nonadminbackup_types.go
@@ -168,6 +168,9 @@ type NonAdminBackupStatus struct {
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
 // +kubebuilder:resource:path=nonadminbackups,shortName=nab
+// +kubebuilder:printcolumn:name="Request-Phase",type="string",JSONPath=".status.phase"
+// +kubebuilder:printcolumn:name="Velero-Phase",type="string",JSONPath=".status.veleroBackup.status.phase"
+// +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
 
 // NonAdminBackup is the Schema for the nonadminbackups API
 type NonAdminBackup struct {

--- a/api/v1alpha1/nonadminbackupstoragelocation_types.go
+++ b/api/v1alpha1/nonadminbackupstoragelocation_types.go
@@ -71,6 +71,10 @@ type NonAdminBackupStorageLocationStatus struct {
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
 // +kubebuilder:resource:path=nonadminbackupstoragelocations,shortName=nabsl
+// +kubebuilder:printcolumn:name="Request-Approved",type="string",JSONPath=".status.conditions[?(@.type=='ClusterAdminApproved')].status"
+// +kubebuilder:printcolumn:name="Request-Phase",type="string",JSONPath=".status.phase"
+// +kubebuilder:printcolumn:name="Velero-Phase",type="string",JSONPath=".status.veleroBackupStorageLocation.status.phase"
+// +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
 
 // NonAdminBackupStorageLocation is the Schema for the nonadminbackupstoragelocations API
 type NonAdminBackupStorageLocation struct {

--- a/api/v1alpha1/nonadminbackupstoragelocationrequest_types.go
+++ b/api/v1alpha1/nonadminbackupstoragelocationrequest_types.go
@@ -84,6 +84,10 @@ type NonAdminBackupStorageLocationRequestStatus struct {
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
 // +kubebuilder:resource:path=nonadminbackupstoragelocationrequests,shortName=nabslrequest
+// +kubebuilder:printcolumn:name="Request-Phase",type="string",JSONPath=".status.phase"
+// +kubebuilder:printcolumn:name="Request-Namespace",type="string",JSONPath=".status.nonAdminBackupStorageLocation.namespace"
+// +kubebuilder:printcolumn:name="Request-Name",type="string",JSONPath=".status.nonAdminBackupStorageLocation.name"
+// +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
 
 // NonAdminBackupStorageLocationRequest is the Schema for the nonadminbackupstoragelocationrequests API
 type NonAdminBackupStorageLocationRequest struct {

--- a/api/v1alpha1/nonadmindownloadrequest_types.go
+++ b/api/v1alpha1/nonadmindownloadrequest_types.go
@@ -50,7 +50,8 @@ type NonAdminDownloadRequestStatus struct {
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
 // +kubebuilder:resource:path=nonadmindownloadrequests,shortName=nadr
-// +kubebuilder:printcolumn:name="Status",type="string",JSONPath=".status.phase"
+// +kubebuilder:printcolumn:name="Request-Phase",type="string",JSONPath=".status.phase"
+// +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
 
 // NonAdminDownloadRequest is the Schema for the nonadmindownloadrequests API.
 type NonAdminDownloadRequest struct {

--- a/api/v1alpha1/nonadminrestore_types.go
+++ b/api/v1alpha1/nonadminrestore_types.go
@@ -137,6 +137,9 @@ type NonAdminRestoreStatus struct {
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
 // +kubebuilder:resource:path=nonadminrestores,shortName=nar
+// +kubebuilder:printcolumn:name="Request-Phase",type="string",JSONPath=".status.phase"
+// +kubebuilder:printcolumn:name="Velero-Phase",type="string",JSONPath=".status.veleroRestore.status.phase"
+// +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
 
 // NonAdminRestore is the Schema for the nonadminrestores API
 type NonAdminRestore struct {

--- a/config/crd/bases/oadp.openshift.io_nonadminbackups.yaml
+++ b/config/crd/bases/oadp.openshift.io_nonadminbackups.yaml
@@ -16,7 +16,17 @@ spec:
     singular: nonadminbackup
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .status.phase
+      name: Request-Phase
+      type: string
+    - jsonPath: .status.veleroBackup.status.phase
+      name: Velero-Phase
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: NonAdminBackup is the Schema for the nonadminbackups API

--- a/config/crd/bases/oadp.openshift.io_nonadminbackupstoragelocationrequests.yaml
+++ b/config/crd/bases/oadp.openshift.io_nonadminbackupstoragelocationrequests.yaml
@@ -16,7 +16,20 @@ spec:
     singular: nonadminbackupstoragelocationrequest
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .status.phase
+      name: Request-Phase
+      type: string
+    - jsonPath: .status.nonAdminBackupStorageLocation.namespace
+      name: Request-Namespace
+      type: string
+    - jsonPath: .status.nonAdminBackupStorageLocation.name
+      name: Request-Name
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: NonAdminBackupStorageLocationRequest is the Schema for the nonadminbackupstoragelocationrequests

--- a/config/crd/bases/oadp.openshift.io_nonadminbackupstoragelocations.yaml
+++ b/config/crd/bases/oadp.openshift.io_nonadminbackupstoragelocations.yaml
@@ -16,7 +16,20 @@ spec:
     singular: nonadminbackupstoragelocation
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .status.conditions[?(@.type=='ClusterAdminApproved')].status
+      name: Request-Approved
+      type: string
+    - jsonPath: .status.phase
+      name: Request-Phase
+      type: string
+    - jsonPath: .status.veleroBackupStorageLocation.status.phase
+      name: Velero-Phase
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: NonAdminBackupStorageLocation is the Schema for the nonadminbackupstoragelocations

--- a/config/crd/bases/oadp.openshift.io_nonadmindownloadrequests.yaml
+++ b/config/crd/bases/oadp.openshift.io_nonadmindownloadrequests.yaml
@@ -18,8 +18,11 @@ spec:
   versions:
   - additionalPrinterColumns:
     - jsonPath: .status.phase
-      name: Status
+      name: Request-Phase
       type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
     name: v1alpha1
     schema:
       openAPIV3Schema:

--- a/config/crd/bases/oadp.openshift.io_nonadminrestores.yaml
+++ b/config/crd/bases/oadp.openshift.io_nonadminrestores.yaml
@@ -16,7 +16,17 @@ spec:
     singular: nonadminrestore
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .status.phase
+      name: Request-Phase
+      type: string
+    - jsonPath: .status.veleroRestore.status.phase
+      name: Velero-Phase
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: NonAdminRestore is the Schema for the nonadminrestores API


### PR DESCRIPTION
Depends-On: https://github.com/openshift/oadp-operator/pull/1709

Implements https://github.com/migtools/oadp-non-admin/issues/232  with additional fields for:

 - NonAdminBackup
 - NonAdminRestore
 - NonAdminBackupStorageLocation

## Why the changes were made

To fix https://github.com/migtools/oadp-non-admin/issues/232 and add similar fields for the NAB and NAR objects.

1. Deployed with local oadp-operator deployment
2. Tested various objects and it's states:

# Prior admin approval or rejections
## Created couple of BSLs - names reflect the idea behind each of them

- suspicious-nabsl (reject)
- nonexistingsecretinns-nabsl (do nothing - no nabslrequest)
- waitingapproval-nabsl (do nothing)
- incorrect-bucket-nabsl (approve)
- perfect-nabsl (approve)

### Before any admin action:
```console
$ oc get nabsl -n non-admin-bsl-test
NAME                          REQUEST-APPROVED   REQUEST-PHASE  VELERO-PHASE       AGE
incorrect-bucket-nabsl        False              New                               2m11s
nonexistingsecretinns-nabsl                      BackingOff                        39s
perfect-nabsl                 False              New                               2m40s
suspicious-sample             False              New                               10s
waitingapproval-nabsl         False              New                               94s
```

Note the `nonexistingsecretinns-nabsl` have not created request - the user must create secret to get to that state

```console
$ oc get nabslrequest
NAME                                                              REQUEST-PHASE   REQUEST-NAMESPACE     REQUEST-NAME
non-admin-bsl-test-incorre-9aa22872-f39d-427c-b352-6924ff9c2175   Pending         non-admin-bsl-test    incorrect-bucket-nabsl
non-admin-bsl-test-perfect-4413c67d-8eb8-42bc-8274-279a91895196   Pending         non-admin-bsl-test    perfect-nabsl
non-admin-bsl-test-suspici-4fbdcebf-2277-4f44-890e-35d765815e1a   Pending         non-admin-bsl-test    suspicious-sample
non-admin-bsl-test-waiting-fcae28c2-d8ea-48e2-a35c-8882bfd865e0   Pending         non-admin-bsl-test    waitingapproval-nabsl
```

Approving or rejecting some:

```console
$ oc get nabslrequest
NAME                                                              REQUEST-PHASE   REQUEST-NAMESPACE     REQUEST-NAME               AGE
non-admin-bsl-test-incorre-9aa22872-f39d-427c-b352-6924ff9c2175   Approved        non-admin-bsl-test    incorrect-bucket-nabsl    4m57s
non-admin-bsl-test-perfect-4413c67d-8eb8-42bc-8274-279a91895196   Approved        non-admin-bsl-test    perfect-nabsl             5m26s
non-admin-bsl-test-suspici-4fbdcebf-2277-4f44-890e-35d765815e1a   Rejected        non-admin-bsl-test    suspicious-sample         2m56s
non-admin-bsl-test-waiting-fcae28c2-d8ea-48e2-a35c-8882bfd865e0   Pending         non-admin-bsl-test    waitingapproval-nabsl     4m20s
```


Now the  NABSL objects
```console
$ oc get nabsl -n non-admin-bsl-test
NAME                          REQUEST-APPROVED   REQUEST-PHASE   VELERO-PHASE   AGE
incorrect-bucket-nabsl        True               Created         Unavailable    8m25s
nonexistingsecretinns-nabsl                      BackingOff                     6m53s
perfect-nabsl                 True               Created         Available      8m54s
suspicious-sample             False              BackingOff                     6m24s
waitingapproval-nabsl         False              New                            7m48s
```

##### Backup

Couple of backup objects were created

```console
$ oc get nab -n non-admin-bsl-test
NAME                       REQUEST-PHASE   VELERO-PHASE       AGE
backup-failed-sample       Created         PartiallyFailed    6s
incorrect-bsl-backup       BackingOff                         3m39s
some-backup                Created         Completed          13s
```

#### Restore

Nice InProgress and Completed status:

```console
$ oc get nar -n non-admin-bsl-test
NAME               REQUEST-PHASE   VELERO-PHASE   AGE
non-existing-nab   BackingOff                     46s

$ oc get nar -n non-admin-bsl-test
NAME               REQUEST-PHASE   VELERO-PHASE   AGE
existing-nab       Created         InProgress     1s
non-existing-nab   BackingOff                     51s

$ oc get nar -n non-admin-bsl-test
NAME               REQUEST-PHASE   VELERO-PHASE   AGE
existing-nab       Created         Completed      3s
non-existing-nab   BackingOff                     53s
```