### PR TITLE
Check the NaBSL status and conditions before creating Velero Backup

### DIFF
--- a/internal/common/function/function.go
+++ b/internal/common/function/function.go
@@ -121,6 +121,15 @@ func ValidateBackupSpec(ctx context.Context, clientInstance client.Client, oadpN
 		} else if err != nil {
 			return fmt.Errorf("NonAdminBackup spec.backupSpec.storageLocation is invalid: %v", err)
 		}
+		if nonAdminBsl.Status.Phase != nacv1alpha1.NonAdminPhaseCreated {
+			return fmt.Errorf("NonAdminBackupStorageLocation is not in created state and can not be used for the NonAdminBackup")
+		}
+
+		for _, condition := range nonAdminBsl.Status.Conditions {
+			if condition.Status != metav1.ConditionTrue {
+				return fmt.Errorf("NonAdminBackupStorageLocation has an unsatisfied condition: %s is %s", condition.Type, condition.Status)
+			}
+		}
 		if nonAdminBsl.Status.VeleroBackupStorageLocation == nil || nonAdminBsl.Status.VeleroBackupStorageLocation.NACUUID == constant.EmptyString {
 			return fmt.Errorf("unable to get VeleroBackupStorageLocation UUID from NonAdminBackupStorageLocation Status")
 		}

--- a/internal/common/function/function_test.go
+++ b/internal/common/function/function_test.go
@@ -407,6 +407,7 @@ func TestValidateBackupSpecEnforcedFields(t *testing.T) {
 						Namespace: "self-service-namespace",
 					},
 					Status: nacv1alpha1.NonAdminBackupStorageLocationStatus{
+						Phase: nacv1alpha1.NonAdminPhaseCreated,
 						VeleroBackupStorageLocation: &nacv1alpha1.VeleroBackupStorageLocation{
 							NACUUID: "user-defined-backup-storage-location-uuid",
 						},

--- a/internal/controller/nonadminbackup_controller_test.go
+++ b/internal/controller/nonadminbackup_controller_test.go
@@ -52,6 +52,7 @@ type nonAdminBackupSingleReconcileScenario struct {
 	resultError                         error
 	nonAdminBackupPriorStatus           *nacv1alpha1.NonAdminBackupStatus
 	nonAdminBackupSpec                  nacv1alpha1.NonAdminBackupSpec
+	nonAdminBackupStorageLocationStatus *nacv1alpha1.NonAdminBackupStorageLocationStatus
 	nonAdminBackupExpectedStatus        nacv1alpha1.NonAdminBackupStatus
 	result                              reconcile.Result
 	createVeleroBackup                  bool
@@ -336,7 +337,8 @@ var _ = ginkgo.Describe("Test single reconciles of NonAdminBackup Reconcile func
 					},
 				}
 				gomega.Expect(k8sClient.Create(ctx, nonAdminBackupStorageLocation)).To(gomega.Succeed())
-				nonAdminBackupStorageLocation.Status.Phase = nacv1alpha1.NonAdminPhaseCreated
+
+				nonAdminBackupStorageLocation.Status = *scenario.nonAdminBackupStorageLocationStatus
 				gomega.Expect(k8sClient.Status().Update(ctx, nonAdminBackupStorageLocation)).To(gomega.Succeed())
 
 				nonAdminBackup.Spec.BackupSpec.StorageLocation = nonAdminBackupStorageLocationName
@@ -536,11 +538,15 @@ var _ = ginkgo.Describe("Test single reconciles of NonAdminBackup Reconcile func
 			veleroBackupExpectedDeleted: true,
 			resultError:                 reconcile.TerminalError(fmt.Errorf("NonAdminBackupStorageLocation not found in the namespace: nonadminbackupstoragelocations.oadp.openshift.io \"wrong\" not found")),
 		}),
-		ginkgo.Entry("When triggered by NonAdminBackup Create event with NonAdminBackupStorageLocation that does not have proper VeleroBackupStorageLocation UUID, should update NonAdminBackup phase to BackingOff", nonAdminBackupSingleReconcileScenario{
+		ginkgo.Entry("When triggered by NonAdminBackup Create event with NonAdminBackupStorageLocation that does not have corresponding VeleroBackupStorageLocation UUID, should update NonAdminBackup phase to BackingOff", nonAdminBackupSingleReconcileScenario{
 			createNonAdminBackupStorageLocation: true,
 			createVeleroBackupStorageLocation:   false,
 			nonAdminBackupSpec: nacv1alpha1.NonAdminBackupSpec{
 				BackupSpec: &velerov1.BackupSpec{},
+			},
+			nonAdminBackupStorageLocationStatus: &nacv1alpha1.NonAdminBackupStorageLocationStatus{
+				Phase:      nacv1alpha1.NonAdminPhaseCreated,
+				Conditions: []metav1.Condition{},
 			},
 			nonAdminBackupExpectedStatus: nacv1alpha1.NonAdminBackupStatus{
 				Phase: nacv1alpha1.NonAdminPhaseBackingOff,
@@ -562,6 +568,18 @@ var _ = ginkgo.Describe("Test single reconciles of NonAdminBackup Reconcile func
 			nonAdminBackupSpec: nacv1alpha1.NonAdminBackupSpec{
 				BackupSpec: &velerov1.BackupSpec{},
 			},
+			nonAdminBackupStorageLocationStatus: &nacv1alpha1.NonAdminBackupStorageLocationStatus{
+				Phase: nacv1alpha1.NonAdminPhaseCreated,
+				Conditions: []metav1.Condition{
+					{
+						Type:               string(nacv1alpha1.NonAdminConditionAccepted),
+						Status:             metav1.ConditionTrue,
+						Reason:             "BackupAccepted",
+						Message:            "backup accepted",
+						LastTransitionTime: metav1.NewTime(time.Now()),
+					},
+				},
+			},
 			nonAdminBackupExpectedStatus: nacv1alpha1.NonAdminBackupStatus{
 				Phase: nacv1alpha1.NonAdminPhaseCreated,
 				Conditions: []metav1.Condition{
@@ -580,6 +598,77 @@ var _ = ginkgo.Describe("Test single reconciles of NonAdminBackup Reconcile func
 				},
 			},
 			result: reconcile.Result{},
+		}),
+		ginkgo.Entry("When triggered by NonAdminBackup Create event with NonAdminBackupStorageLocation phase different then created, should fail to create Velero Backup object", nonAdminBackupSingleReconcileScenario{
+			createNonAdminBackupStorageLocation: true,
+			createVeleroBackupStorageLocation:   true,
+			nonAdminBackupSpec: nacv1alpha1.NonAdminBackupSpec{
+				BackupSpec: &velerov1.BackupSpec{},
+			},
+			nonAdminBackupStorageLocationStatus: &nacv1alpha1.NonAdminBackupStorageLocationStatus{
+				Phase: nacv1alpha1.NonAdminPhaseBackingOff,
+				Conditions: []metav1.Condition{
+					{
+						Type:               string(nacv1alpha1.NonAdminConditionAccepted),
+						Status:             metav1.ConditionTrue,
+						Reason:             "BackupAccepted",
+						Message:            "backup accepted",
+						LastTransitionTime: metav1.NewTime(time.Now()),
+					},
+				},
+			},
+			nonAdminBackupExpectedStatus: nacv1alpha1.NonAdminBackupStatus{
+				Phase: nacv1alpha1.NonAdminPhaseBackingOff,
+				Conditions: []metav1.Condition{
+					{
+						Type:    string(nacv1alpha1.NonAdminConditionAccepted),
+						Status:  metav1.ConditionFalse,
+						Reason:  "InvalidBackupSpec",
+						Message: "NonAdminBackupStorageLocation is not in created state and can not be used for the NonAdminBackup",
+					},
+				},
+			},
+			veleroBackupExpectedDeleted: true,
+			resultError:                 fmt.Errorf("NonAdminBackupStorageLocation is not in created state and can not be used for the NonAdminBackup"),
+		}),
+		ginkgo.Entry("When triggered by NonAdminBackup Create event with NonAdminBackupStorageLocation phase created and one of the conditions False, should fail to create Velero Backup object", nonAdminBackupSingleReconcileScenario{
+			createNonAdminBackupStorageLocation: true,
+			createVeleroBackupStorageLocation:   true,
+			nonAdminBackupSpec: nacv1alpha1.NonAdminBackupSpec{
+				BackupSpec: &velerov1.BackupSpec{},
+			},
+			nonAdminBackupStorageLocationStatus: &nacv1alpha1.NonAdminBackupStorageLocationStatus{
+				Phase: nacv1alpha1.NonAdminPhaseCreated,
+				Conditions: []metav1.Condition{
+					{
+						Type:               string(nacv1alpha1.NonAdminConditionAccepted),
+						Status:             metav1.ConditionTrue,
+						Reason:             "BackupAccepted",
+						Message:            "backup accepted",
+						LastTransitionTime: metav1.NewTime(time.Now()),
+					},
+					{
+						Type:               string(nacv1alpha1.NonAdminBSLConditionSecretSynced),
+						Status:             metav1.ConditionFalse,
+						Reason:             "SecretSyncFailed",
+						Message:            "secret sync failed",
+						LastTransitionTime: metav1.NewTime(time.Now()),
+					},
+				},
+			},
+			nonAdminBackupExpectedStatus: nacv1alpha1.NonAdminBackupStatus{
+				Phase: nacv1alpha1.NonAdminPhaseBackingOff,
+				Conditions: []metav1.Condition{
+					{
+						Type:    string(nacv1alpha1.NonAdminConditionAccepted),
+						Status:  metav1.ConditionFalse,
+						Reason:  "InvalidBackupSpec",
+						Message: "NonAdminBackupStorageLocation has an unsatisfied condition: SecretSynced is False",
+					},
+				},
+			},
+			veleroBackupExpectedDeleted: true,
+			resultError:                 fmt.Errorf("NonAdminBackupStorageLocation has an unsatisfied condition: SecretSynced is False"),
 		}),
 		ginkgo.Entry("When triggered by NonAdminBackup deleteNonAdmin spec field when BackupSpec is invalid, should delete NonAdminBackup without error", nonAdminBackupSingleReconcileScenario{
 			nonAdminBackupSpec: nacv1alpha1.NonAdminBackupSpec{


### PR DESCRIPTION
Fixes #246

Ensure the state of the NaBSL is satisfying the Backup operation, in a case the admin redefined enforcement the NaBSL state was correctly synced back from the enforcement, however we disallowed real updated of the Velero BSL object causing NaBSL being in not allowed state, however previous Velero BSL fully functional.

This logic fixes that issue.

## Why the changes were made

To fix #246 

## How to test the changes made

1. As described in the #246 issue:
2. Create enforcements for the NaBSL in the DPA
3. Create NaBSL to satisfy enforcements
4. Change the NaBSL enforcements in the DPA
5. Try to perform Backup operation using the NaBSL

Expected result: Backup can not be created.