### PR TITLE
Fix message for the objectStorage enforcement

### DIFF
--- a/internal/common/function/function.go
+++ b/internal/common/function/function.go
@@ -264,7 +264,7 @@ func ValidateBslSpec(ctx context.Context, clientInstance client.Client, nonAdmin
 		case "StorageType":
 			enforcedStorageType := compareStorageTypes(enforcedField, currentField)
 			if enforcedStorageType != constant.EmptyString {
-				return fmt.Errorf("the administrator has restricted spec.backupStorageLocationSpec.%v field value to %v", enforcedFieldName, enforcedStorageType)
+				return fmt.Errorf("the administrator has restricted spec.backupStorageLocationSpec.objectStorage field value(s) to: %v", enforcedStorageType)
 			}
 		default:
 			if !enforcedField.IsZero() && !currentField.IsZero() && !reflect.DeepEqual(enforcedField.Interface(), currentField.Interface()) {
@@ -336,7 +336,7 @@ func compareStorageTypes(enforcedStorageType, currentStorageType reflect.Value) 
 				if enforcedStorage.ObjectStorage.Bucket != currentStorage.ObjectStorage.Bucket ||
 					enforcedStorage.ObjectStorage.Prefix != currentStorage.ObjectStorage.Prefix ||
 					string(enforcedStorage.ObjectStorage.CACert) != string(currentStorage.ObjectStorage.CACert) {
-					return fmt.Sprintf("objectStorage: bucket: %s, prefix: %s, caCert: %s",
+					return fmt.Sprintf("bucket: %s, prefix: %s, caCert: %s",
 						enforcedStorage.ObjectStorage.Bucket,
 						enforcedStorage.ObjectStorage.Prefix,
 						string(enforcedStorage.ObjectStorage.CACert))


### PR DESCRIPTION
Fixes #247, which incorrectly showed StorageType
in the BslSpecValidation message when the
objectStorage was enforced by the admin.

## Why the changes were made

To fix #247 

## How to test the changes made

As described in the bug #247 

1. Create enforcements for the NaBSL in the DPA on the objectStorage spec part
2. Create NaBSL that **do not satisfy** enforcements 
3. Check the condition message on the NaBSL object