### PR TITLE
fix: envtest version for OCP 4.19

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,9 @@
 
 # Image URL to use all building/pushing image targets
 IMG ?= quay.io/konveyor/oadp-non-admin:latest
-# Kubernetes version from OpenShift 4.16.x https://openshift-release.apps.ci.l2s4.p1.openshiftapps.com/#4-stable
+# Kubernetes version from OpenShift 4.19.x https://openshift-release.apps.ci.l2s4.p1.openshiftapps.com/#4-stable
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
-ENVTEST_K8S_VERSION = 1.29
+ENVTEST_K8S_VERSION = 1.32
 
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
 ifeq (,$(shell go env GOBIN))
@@ -166,7 +166,7 @@ GOLANGCI_LINT = $(LOCALBIN)/golangci-lint-$(GOLANGCI_LINT_VERSION)
 ## Tool Versions
 KUSTOMIZE_VERSION ?= v5.3.0
 CONTROLLER_TOOLS_VERSION ?= v0.16.5
-ENVTEST_VERSION ?= v0.0.0-20240320141353-395cfc7486e6
+ENVTEST_VERSION ?= v0.0.0-20250308055145-5fe7bb3edc86
 GOLANGCI_LINT_VERSION ?= v1.62.2
 
 .PHONY: kustomize

--- a/internal/controller/suite_test.go
+++ b/internal/controller/suite_test.go
@@ -66,7 +66,7 @@ var _ = ginkgo.BeforeSuite(func() {
 		// Note that you must have the required binaries setup under the bin directory to perform
 		// the tests directly. When we run make test it will be setup and used automatically.
 		BinaryAssetsDirectory: filepath.Join("..", "..", "bin", "k8s",
-			fmt.Sprintf("1.29.3-%s-%s", runtime.GOOS, runtime.GOARCH)),
+			fmt.Sprintf("1.32.0-%s-%s", runtime.GOOS, runtime.GOARCH)),
 	}
 
 	var err error


### PR DESCRIPTION
## Why the changes were made

Update Kubernetes version used in envtest to match version used by OCP 4.19. Using same setup-envtest version as OADP. Reference https://github.com/openshift/oadp-operator/pull/1682

## How to test the changes made

Check CI logs.
