### PR TITLE
OADP-5799:Allow users to set NAC logging to json format

### DIFF
--- a/cmd/main_test.go
+++ b/cmd/main_test.go
@@ -25,6 +25,11 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
+const (
+	consoleEncoderType = "zapcore.consoleEncoder"
+	jsonEncoderType    = "*zapcore.jsonEncoder"
+)
+
 func Test_translateLogrusToZapLevel(t *testing.T) {
 	for _, level := range logrus.AllLevels {
 		t.Run(level.String(), func(t *testing.T) {
@@ -49,22 +54,22 @@ func TestEncoderForFormat(t *testing.T) {
 		{
 			name:        "json format",
 			inputFormat: "json",
-			wantTypeStr: "*zapcore.jsonEncoder",
+			wantTypeStr: jsonEncoderType,
 		},
 		{
 			name:        "text format",
 			inputFormat: "text",
-			wantTypeStr: "zapcore.consoleEncoder",
+			wantTypeStr: consoleEncoderType,
 		},
 		{
 			name:        "invalid format defaults to text",
 			inputFormat: "invalid",
-			wantTypeStr: "zapcore.consoleEncoder",
+			wantTypeStr: consoleEncoderType,
 		},
 		{
 			name:        "empty format defaults to text",
 			inputFormat: "",
-			wantTypeStr: "zapcore.consoleEncoder",
+			wantTypeStr: consoleEncoderType,
 		},
 	}
 

--- a/cmd/main_test.go
+++ b/cmd/main_test.go
@@ -18,6 +18,7 @@ limitations under the License.
 package main
 
 import (
+	"reflect"
 	"testing"
 
 	_ "github.com/onsi/ginkgo/v2" // To fix: flag provided but not defined: -ginkgo.vv
@@ -34,6 +35,48 @@ func Test_translateLogrusToZapLevel(t *testing.T) {
 			}
 			if zapLevel.String() == "" {
 				t.Error("empty zap level unexpected")
+			}
+		})
+	}
+}
+
+func TestEncoderForFormat(t *testing.T) {
+	tests := []struct {
+		name        string
+		inputFormat string
+		wantTypeStr string
+	}{
+		{
+			name:        "json format",
+			inputFormat: "json",
+			wantTypeStr: "*zapcore.jsonEncoder",
+		},
+		{
+			name:        "text format",
+			inputFormat: "text",
+			wantTypeStr: "zapcore.consoleEncoder",
+		},
+		{
+			name:        "invalid format defaults to text",
+			inputFormat: "invalid",
+			wantTypeStr: "zapcore.consoleEncoder",
+		},
+		{
+			name:        "empty format defaults to text",
+			inputFormat: "",
+			wantTypeStr: "zapcore.consoleEncoder",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			enc := encoderForFormat(tt.inputFormat)
+			actualType := reflect.TypeOf(enc).String()
+			t.Logf("Returned type for format %q: %T", tt.inputFormat, enc)
+
+			if actualType != tt.wantTypeStr {
+				t.Errorf("encoderForFormat(%q) returned encoder of type %s, want %s",
+					tt.inputFormat, actualType, tt.wantTypeStr)
 			}
 		})
 	}

--- a/internal/common/constant/constant.go
+++ b/internal/common/constant/constant.go
@@ -62,7 +62,8 @@ const (
 	// 4 = Info
 	// 5 = Debug
 	// 6 = Trace
-	LogLevelEnvVar = "LOG_LEVEL"
+	LogLevelEnvVar  = "LOG_LEVEL"
+	LogFormatEnvVar = "LOG_FORMAT"
 )
 
 // EmptyString defines a constant for the empty string


### PR DESCRIPTION
## Why the changes were made

<!-- Explain why this PR is important, what problems it fixes, link related issues -->

Fixes https://issues.redhat.com/browse/OADP-5799
Depends on https://github.com/openshift/oadp-operator/pull/1687
Fixes https://github.com/migtools/oadp-non-admin/issues/254

## How to test the changes made

<!-- Explain how the changes introduced by this PR can be tested and verified, with commands and pictures -->

- Try passing `logFormat` via DPA as `json` or `text`
- Check the NAC deployment/Pod for the value of `LOG_FORMAT` env var
- Finally, check the format of logs in NAC controller pod