### PR TITLE
fixup! ⬆ Bump golangci/golangci-lint-action from 6 to 7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Go linters
         uses: golangci/golangci-lint-action@v7
         with:
-          version: v1.62.2
+          version: v2.0.2
 
       - name: Go dependencies
         run: make check-go-dependencies

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,90 +1,32 @@
-# Documentation reference https://github.com/golangci/golangci-lint/blob/v1.62.2/.golangci.reference.yml
+# Documentation reference https://github.com/golangci/golangci-lint/blob/v2.0.2/.golangci.reference.yml
+version: "2"
 run:
   modules-download-mode: readonly
   allow-parallel-runners: true
 
 output:
   formats:
-    - format: colored-line-number
+    text:
       path: stdout
-  print-issued-lines: true
-  print-linter-name: true
-  uniq-by-line: true
-  sort-results: true
+      colors: true
+      print-issued-lines: true
+      print-linter-name: true
 
-linters-settings:
-  dogsled:
-    max-blank-identifiers: 2
-  errcheck:
-    check-type-assertions: true
-    check-blank: true
-  gci:
-    sections:
-      - standard
-      - default
-      - prefix(github.com/migtools/oadp-non-admin)
-  goconst:
-    min-len: 3
-    min-occurrences: 5
-  gofmt:
-    simplify: true
-  goheader:
-    # copy from ./hack/boilerplate.go.txt
-    template: |-
-      Copyright 2024.
-
-      Licensed under the Apache License, Version 2.0 (the "License");
-      you may not use this file except in compliance with the License.
-      You may obtain a copy of the License at
-
-          http://www.apache.org/licenses/LICENSE-2.0
-
-      Unless required by applicable law or agreed to in writing, software
-      distributed under the License is distributed on an "AS IS" BASIS,
-      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-      See the License for the specific language governing permissions and
-      limitations under the License.
-  govet:
-    enable-all: true
-  importas:
-    no-unaliased: true
-    alias:
-      - pkg: github.com/vmware-tanzu/velero/pkg/apis/velero/v1
-        alias: velerov1
-      - pkg: k8s.io/apimachinery/pkg/apis/meta/v1
-        alias: metav1
-      - pkg: k8s.io/api/core/v1
-        alias: corev1
-      - pkg: github.com/migtools/oadp-non-admin/api/v1alpha1
-        alias: nacv1alpha1
-  misspell:
-    locale: US
-  nakedret:
-    max-func-lines: 30
-  nolintlint:
-    allow-unused: false
-    allow-no-explanation: []
-    require-explanation: true
-    require-specific: true
-  revive:
-    enable-all-rules: true
-    rules:
-      - name: line-length-limit
-        disabled: true
-      - name: function-length
-        disabled: true
-      - name: max-public-structs
-        disabled: true
-      # TODO remove
-      - name: cyclomatic
-        disabled: true
-      - name: cognitive-complexity
-        disabled: true
-  unparam:
-    check-exported: true
+formatters:
+  enable:
+    - gci
+    - gofmt
+  settings:
+    gci:
+      sections:
+        - standard
+        - default
+        - prefix(github.com/migtools/oadp-non-admin)
+    gofmt:
+      simplify: true
 
 linters:
-  disable-all: true
+  default: none
   enable:
     - asasalint
     - asciicheck
@@ -96,14 +38,11 @@ linters:
     - durationcheck
     - errcheck
     - errchkjson
-    - gci
     - ginkgolinter
     - goconst
-    - gofmt
     - goheader
     - goprintffuncname
     - gosec
-    - gosimple
     - govet
     - importas
     - ineffassign
@@ -116,31 +55,91 @@ linters:
     - nosprintfhostport
     - revive
     - staticcheck
-    - stylecheck
     - unconvert
     - unparam
     - unused
     - usestdlibvars
-  fast: false
+  settings:
+    dogsled:
+      max-blank-identifiers: 2
+    errcheck:
+      check-type-assertions: true
+      check-blank: true
+    goconst:
+      min-len: 3
+      min-occurrences: 5
+    goheader:
+      # copy from ./hack/boilerplate.go.txt
+      template: |-
+        Copyright 2024.
+
+        Licensed under the Apache License, Version 2.0 (the "License");
+        you may not use this file except in compliance with the License.
+        You may obtain a copy of the License at
+
+            http://www.apache.org/licenses/LICENSE-2.0
+
+        Unless required by applicable law or agreed to in writing, software
+        distributed under the License is distributed on an "AS IS" BASIS,
+        WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+        See the License for the specific language governing permissions and
+        limitations under the License.
+    govet:
+      enable-all: true
+    importas:
+      no-unaliased: true
+      alias:
+        - pkg: github.com/vmware-tanzu/velero/pkg/apis/velero/v1
+          alias: velerov1
+        - pkg: k8s.io/apimachinery/pkg/apis/meta/v1
+          alias: metav1
+        - pkg: k8s.io/api/core/v1
+          alias: corev1
+        - pkg: github.com/migtools/oadp-non-admin/api/v1alpha1
+          alias: nacv1alpha1
+    misspell:
+      locale: US
+    nakedret:
+      max-func-lines: 30
+    nolintlint:
+      allow-unused: false
+      allow-no-explanation: []
+      require-explanation: true
+      require-specific: true
+    revive:
+      enable-all-rules: true
+      rules:
+        - name: line-length-limit
+          disabled: true
+        - name: function-length
+          disabled: true
+        - name: max-public-structs
+          disabled: true
+        # TODO remove
+        - name: cyclomatic
+          disabled: true
+        - name: cognitive-complexity
+          disabled: true
+    unparam:
+      check-exported: true
+  exclusions:
+    paths:
+      - test/*
+    rules:
+      - linters:
+          - revive
+        text: "^struct-tag: unknown option 'inline' in JSON tag$"
+      - linters:
+          - revive
+        text: "^add-constant: avoid magic numbers like '0', create a named constant for it$"
+      - linters:
+          - revive
+        text: "^add-constant: avoid magic numbers like '1', create a named constant for it$"
 
 issues:
-  exclude-dirs:
-    - test/*
-  exclude-dirs-use-default: false
-  exclude-use-default: false
-  exclude-rules:
-    - linters:
-        - revive
-      text: "^struct-tag: unknown option 'inline' in JSON tag$"
-    - linters:
-        - revive
-      text: "^add-constant: avoid magic numbers like '0', create a named constant for it$"
-    - linters:
-        - revive
-      text: "^add-constant: avoid magic numbers like '1', create a named constant for it$"
+  uniq-by-line: true
   max-issues-per-linter: 0
   max-same-issues: 0
 
 severity:
-  default-severity: error
-  case-sensitive: false
+  default: error

--- a/Makefile
+++ b/Makefile
@@ -167,7 +167,7 @@ GOLANGCI_LINT = $(LOCALBIN)/golangci-lint-$(GOLANGCI_LINT_VERSION)
 KUSTOMIZE_VERSION ?= v5.3.0
 CONTROLLER_TOOLS_VERSION ?= v0.16.5
 ENVTEST_VERSION ?= v0.0.0-20240320141353-395cfc7486e6
-GOLANGCI_LINT_VERSION ?= v1.62.2
+GOLANGCI_LINT_VERSION ?= v2.0.2
 
 .PHONY: kustomize
 kustomize: $(KUSTOMIZE) ## Download kustomize locally if necessary.
@@ -187,7 +187,7 @@ $(ENVTEST): $(LOCALBIN)
 .PHONY: golangci-lint
 golangci-lint: $(GOLANGCI_LINT) ## Download golangci-lint locally if necessary.
 $(GOLANGCI_LINT): $(LOCALBIN)
-	$(call go-install-tool,$(GOLANGCI_LINT),github.com/golangci/golangci-lint/cmd/golangci-lint,${GOLANGCI_LINT_VERSION})
+	$(call go-install-tool,$(GOLANGCI_LINT),github.com/golangci/golangci-lint/v2/cmd/golangci-lint,${GOLANGCI_LINT_VERSION})
 
 # go-install-tool will 'go install' any package with custom target and name of binary, if it doesn't exist
 # $1 - target path with name of binary (ideally with version)


### PR DESCRIPTION
## Why the changes were made

Allow use of golangci-lint-action 7

## How to test the changes made

Check CI logs and run `make lint`
