### PR TITLE
Update master to oadp-dev references

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,11 +3,11 @@ name: Continuous Integration
 on:
   push:
     branches:
-      - master
+      - oadp-dev
       - oadp-1.5
   pull_request:
     branches:
-      - master
+      - oadp-dev
       - oadp-1.5
   schedule:
     - cron: '0 0 * * 1' # Every Monday at 00:00 UTC

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -27,7 +27,7 @@ resources:
 #- ../prometheus
 
 patches:
-# Create same deployment as OADP https://github.com/openshift/oadp-operator/blob/master/controllers/nonadmin_controller.go
+# Create same deployment as OADP https://github.com/openshift/oadp-operator/blob/oadp-dev/controllers/nonadmin_controller.go
 - path: manager_oadp_patch.yaml
 # Protect the /metrics endpoint by putting it behind auth.
 # If you want your controller-manager to expose the /metrics

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -26,7 +26,7 @@ If you are upgrading project's kubebuilder version, please follow [upgrade kubeb
 
 To install OADP operator from default or a release branch in your cluster, with related OADP NAC from default or same release branch, run
 ```sh
-git clone --depth=1 git@github.com:openshift/oadp-operator.git -b master # or appropriate branch
+git clone --depth=1 git@github.com:openshift/oadp-operator.git -b oadp-dev # or appropriate branch
 cd oadp-operator
 make deploy-olm
 ```
@@ -36,7 +36,7 @@ To install OADP operator from a branch in your cluster, with OADP NAC from curre
 export NAC_PATH=$PWD # or appropriate NAC repository path, already with current branch pointing to development branch
 export DEV_IMG=ttl.sh/oadp-non-admin-$(git rev-parse --short HEAD)-$(echo $RANDOM):1h
 IMG=$DEV_IMG make docker-build docker-push
-git clone --depth=1 git@github.com:openshift/oadp-operator.git -b master # or appropriate branch
+git clone --depth=1 git@github.com:openshift/oadp-operator.git -b oadp-dev # or appropriate branch
 cd oadp-operator
 NON_ADMIN_CONTROLLER_PATH=$NAC_PATH NON_ADMIN_CONTROLLER_IMG=$DEV_IMG make update-non-admin-manifests deploy-olm
 ```
@@ -141,7 +141,7 @@ If Velero version or its objects needs changes, follow this workflow:
 
 To upgrade OADP version, run
 ```sh
-go get github.com/openshift/oadp-operator@master # or appropriate branch
+go get github.com/openshift/oadp-operator@oadp-dev # or appropriate branch
 ```
 
 TODO when to update oadp-operator version in go.mod?


### PR DESCRIPTION
Update to include oadp-operator master to oadp-dev rename.

## Why the changes were made

OADP Git repo branch unification.

Note:
This PR Can be merged only after oadp-operator branch is renamed.