### PR TITLE
add template konflux dockerfile

### DIFF
--- a/konflux.Dockerfile
+++ b/konflux.Dockerfile
@@ -1,0 +1,25 @@
+FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_golang_1.25 AS builder
+COPY . .
+WORKDIR $APP_ROOT/app/
+COPY go.mod go.mod
+COPY go.sum go.sum
+RUN go mod download
+COPY cmd/main.go cmd/main.go
+COPY api/ api/
+COPY internal/ internal/
+ENV BUILDTAGS strictfipsruntime
+ENV GOEXPERIMENT strictfipsruntime
+RUN CGO_ENABLED=1 GOOS=linux go build -tags "$BUILDTAGS" -mod=mod -a -o manager cmd/main.go
+
+FROM registry.redhat.io/ubi9/ubi:latest
+COPY --from=builder $APP_ROOT/app/manager /manager
+
+USER 65532:65532
+
+ENTRYPOINT ["/manager"]
+
+LABEL description="OpenShift API for Data Protection - Non-Admin"
+LABEL io.k8s.description="OpenShift API for Data Protection - Non-Admin"
+LABEL io.k8s.display-name="OADP Non-Admin"
+LABEL io.openshift.tags="migration"
+LABEL summary="OpenShift API for Data Protection - Non-Admin"


### PR DESCRIPTION
## Why the changes were made

template konflux dockerfile, can be cp to oadp-1.6

## How to test the changes made



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added multi-stage Dockerfile configuration for containerized application builds using official Red Hat base images.
  * Implemented security hardening with non-root container user.
  * Added container metadata labels for image identification and Kubernetes/OpenShift integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->