### PR TITLE
[oadp-dev] Fix IncludedClusterScopedResources test panic

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM --platform=$BUILDPLATFORM golang:1.25 AS builder
+FROM --platform=$BUILDPLATFORM golang:1.26 AS builder
 ARG BUILDPLATFORM
 ARG TARGETOS
 ARG TARGETARCH

--- a/config/crd/bases/oadp.openshift.io_nonadminbackupstoragelocationrequests.yaml
+++ b/config/crd/bases/oadp.openshift.io_nonadminbackupstoragelocationrequests.yaml
@@ -146,10 +146,38 @@ spec:
                             description: Bucket is the bucket to use for object storage.
                             type: string
                           caCert:
-                            description: CACert defines a CA bundle to use when verifying
-                              TLS connections to the provider.
+                            description: |-
+                              CACert defines a CA bundle to use when verifying TLS connections to the provider.
+                              Deprecated: Use CACertRef instead.
                             format: byte
                             type: string
+                          caCertRef:
+                            description: |-
+                              CACertRef is a reference to a Secret containing the CA certificate bundle to use
+                              when verifying TLS connections to the provider. The Secret must be in the same
+                              namespace as the BackupStorageLocation.
+                            properties:
+                              key:
+                                description: The key of the secret to select from.  Must
+                                  be a valid secret key.
+                                type: string
+                              name:
+                                default: ""
+                                description: |-
+                                  Name of the referent.
+                                  This field is effectively required, but due to backwards compatibility is
+                                  allowed to be empty. Instances of this type with an empty value here are
+                                  almost certainly wrong.
+                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                type: string
+                              optional:
+                                description: Specify whether the Secret or its key
+                                  must be defined
+                                type: boolean
+                            required:
+                            - key
+                            type: object
+                            x-kubernetes-map-type: atomic
                           prefix:
                             description: Prefix is the path inside a bucket to use
                               for Velero storage. Optional.

--- a/config/crd/bases/oadp.openshift.io_nonadminbackupstoragelocations.yaml
+++ b/config/crd/bases/oadp.openshift.io_nonadminbackupstoragelocations.yaml
@@ -114,10 +114,38 @@ spec:
                         description: Bucket is the bucket to use for object storage.
                         type: string
                       caCert:
-                        description: CACert defines a CA bundle to use when verifying
-                          TLS connections to the provider.
+                        description: |-
+                          CACert defines a CA bundle to use when verifying TLS connections to the provider.
+                          Deprecated: Use CACertRef instead.
                         format: byte
                         type: string
+                      caCertRef:
+                        description: |-
+                          CACertRef is a reference to a Secret containing the CA certificate bundle to use
+                          when verifying TLS connections to the provider. The Secret must be in the same
+                          namespace as the BackupStorageLocation.
+                        properties:
+                          key:
+                            description: The key of the secret to select from.  Must
+                              be a valid secret key.
+                            type: string
+                          name:
+                            default: ""
+                            description: |-
+                              Name of the referent.
+                              This field is effectively required, but due to backwards compatibility is
+                              allowed to be empty. Instances of this type with an empty value here are
+                              almost certainly wrong.
+                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                            type: string
+                          optional:
+                            description: Specify whether the Secret or its key must
+                              be defined
+                            type: boolean
+                        required:
+                        - key
+                        type: object
+                        x-kubernetes-map-type: atomic
                       prefix:
                         description: Prefix is the path inside a bucket to use for
                           Velero storage. Optional.

--- a/config/crd/bases/oadp.openshift.io_nonadminrestores.yaml
+++ b/config/crd/bases/oadp.openshift.io_nonadminrestores.yaml
@@ -419,6 +419,33 @@ spec:
                     - name
                     type: object
                     x-kubernetes-map-type: atomic
+                  resourcePolicy:
+                    description: |-
+                      ResourcePolicy specifies the reference to a ConfigMap containing resource
+                      filter policies for this restore. The ConfigMap can contain a
+                      namespacedFilterPolicies section that specifies per-namespace resource type
+                      filters, label selectors, and resource name patterns, and a
+                      clusterScopedFilterPolicy section for per-kind filtering of cluster-scoped
+                      resources. The ConfigMap format is the same as for BackupSpec.ResourcePolicy.
+                    nullable: true
+                    properties:
+                      apiGroup:
+                        description: |-
+                          APIGroup is the group for the resource being referenced.
+                          If APIGroup is not specified, the specified Kind must be in the core API group.
+                          For any other third-party types, APIGroup is required.
+                        type: string
+                      kind:
+                        description: Kind is the type of resource being referenced
+                        type: string
+                      name:
+                        description: Name is the name of resource being referenced
+                        type: string
+                    required:
+                    - kind
+                    - name
+                    type: object
+                    x-kubernetes-map-type: atomic
                   restorePVs:
                     description: |-
                       RestorePVs specifies whether to restore all included

--- a/internal/controller/nonadminbackup_controller_test.go
+++ b/internal/controller/nonadminbackup_controller_test.go
@@ -1588,7 +1588,6 @@ var _ = ginkgo.Describe("Test full reconcile loop of NonAdminBackup Controller",
 			spec: nacv1alpha1.NonAdminBackupSpec{
 				BackupSpec: &velerov1.BackupSpec{
 					ExcludedNamespaceScopedResources: []string{"*"},
-					IncludedClusterScopedResources:   []string{"persistentvolumes"},
 				},
 			},
 			status: nacv1alpha1.NonAdminBackupStatus{
@@ -1598,7 +1597,6 @@ var _ = ginkgo.Describe("Test full reconcile loop of NonAdminBackup Controller",
 					Status:    nil,
 					Spec: &velerov1.BackupSpec{
 						ExcludedNamespaceScopedResources: []string{"*"},
-						IncludedClusterScopedResources:   []string{"persistentvolumes"},
 						ExcludedClusterScopedResources: []string{
 							"securitycontextconstraints",
 							"clusterroles",


### PR DESCRIPTION
## Summary

Fixes multiple CI failures on the `oadp-dev` scheduled run ([#854](https://github.com/migtools/oadp-non-admin/actions/runs/29713283729)):

- **golang-check**: Remove `IncludedClusterScopedResources` from the wildcard exclusion test scenario — this field is rejected by `ValidateBackupSpec` as restricted, causing the reconciler to fail before creating a VeleroBackup and the test to panic on nil `Status.VeleroBackup`
- **container-check**: Update Dockerfile from `golang:1.25` to `golang:1.26` to match `go.mod` requirement
- **project-check**: Regenerate CRD manifests (`make manifests`)

The **oadp-compatibility-check** failure (`make update-velero-manifests`) cannot be fixed here — oadp-operator's `oadp-dev` branch pins an older velero version than oadp-non-admin's. Once oadp-operator bumps its velero to match, that check should pass.

## Test plan

- [ ] `golang-check` passes (panicking test no longer sets a restricted field)
- [ ] `container-check` passes (Dockerfile Go version matches go.mod)
- [ ] `project-check` passes (CRD manifests up to date)

*Posted via [Claude Code](https://claude.ai/code)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for referencing Secret-based CA certificate bundles for non-admin backup storage locations.
  - Added restore resource policy references through ConfigMaps.
- **Improvements**
  - Marked the existing inline CA certificate setting as deprecated in favor of Secret references.
  - Updated the build environment to use Go 1.26.
- **Bug Fixes**
  - Corrected backup configuration expectations when excluding all namespace-scoped resources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->