### PR TITLE
Remove inactive users from OWNERS

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,14 +1,11 @@
 approvers:
   - kaovilai
   - mpryc
-  - mrnold
-  - rayfordj
   - shawn-hurley
   - shubham-pampattiwar
   - sseago
 reviewers:
   - kaovilai
   - mpryc
-  - mrnold
   - shubham-pampattiwar
   - sseago


### PR DESCRIPTION
Remove inactive users from OWNERS approvers/reviewers.

---
@kaovilai requested in [Slack thread](https://redhat-internal.slack.com/archives/C0BHTAWB542/p1785509108887839)